### PR TITLE
added nodeVersion support with fallback to 0.10.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,15 @@ This will create two files in your Meteor Up project directory, which are:
     }
   ],
 
-  //install MongoDB in the server
-  "setupMongo": false,
-  //install Nodejs in the server
+  //install MongoDB in the server, does not destroy local mongo db on future setup
+  "setupMongo": true,
+  
   //WARNING: Nodejs is required! Only skip if you already have nodejs installed on server.
   "setupNode": true,
+  
+  //WARNING: If nodeVersion omitted will setup 0.10.24 by default. Do not use v, only version number.
+  "nodeVersion": "0.10.22",
+  
   //install PhantomJS in the server
   "setupPhantom": true,
 

--- a/example/mup.json
+++ b/example/mup.json
@@ -10,8 +10,17 @@
     }
   ],
 
-  //install MongoDB in the server
+  //install MongoDB in the server, does not destroy local mongo db on future setup
   "setupMongo": true,
+  
+  //WARNING: Nodejs is required! Only skip if you already have nodejs installed on server.
+  "setupNode": true,
+  
+  //WARNING: If nodeVersion omitted will setup 0.10.24 by default. Do not use v, only version number.
+  "nodeVersion": "0.10.22",
+  
+  //install PhantomJS in the server
+  "setupPhantom": true,
 
   //location of app (local directory)
   "app": "/path/to/the/app",

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -44,7 +44,7 @@ Actions.prototype._createSession = function(config) {
 };
 
 Actions.prototype.setup = function() {
-  var taskList = taskLists.setup(this.config.setupMongo, this.config.setupNode, this.config.setupPhantom);
+  var taskList = taskLists.setup(this.config.setupMongo, this.config.setupNode, this.config.nodeVersion, this.config.setupPhantom);
   taskList.run(this.sessions);
 };
 

--- a/lib/taskLists.js
+++ b/lib/taskLists.js
@@ -5,13 +5,16 @@ var path = require('path');
 var SCRIPT_DIR = path.resolve(__dirname, '../scripts');
 var TEMPLATES_DIR = path.resolve(__dirname, '../templates');
 
-exports.setup = function(installMongo, setupNode, setupPhantom) {
+exports.setup = function(installMongo, setupNode, nodeVersion, setupPhantom) {
   var taskList = nodemiral.taskList('Setting Up');
   
   // Installation
   if (setupNode) {
     taskList.executeScript('installing node', {
-      script: path.resolve(SCRIPT_DIR, 'install-node.sh')
+      script: path.resolve(SCRIPT_DIR, 'install-node.sh'),
+      vars: {
+        nodeVersion: nodeVersion
+      },
     });
   }
 

--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -1,14 +1,30 @@
 #!/bin/bash
 
-#remove the lock
-set +e
-sudo rm /var/lib/dpkg/lock > /dev/null
-sudo rm /var/cache/apt/archives/lock > /dev/null
-sudo dpkg --configure -a
-set -e
+# required to update system
+sudo apt-get update
 
-sudo apt-get update
-sudo apt-get install -y python-software-properties python g++ make
-sudo add-apt-repository -y ppa:chris-lea/node.js
-sudo apt-get update
-sudo apt-get install -y nodejs
+# install nodejs - either nodeVersion or last known version supporting websockets with Meteor
+
+<% if (nodeVersion) { %>
+  NODE_VERSION=<%= nodeVersion %>
+<% } else {%>
+  NODE_VERSION=0.10.24
+<% } %>
+
+ARCH=`uname -m`
+if [[ $ARCH == 'x86_64' ]]; then
+  NODE_ARCH=x64
+else
+  NODE_ARCH=x86
+fi
+
+sudo apt-get -y install build-essential libssl-dev git curl
+
+cd /tmp
+wget http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$NODE_ARCH.tar.gz
+tar xvzf node-v$NODE_VERSION-linux-$NODE_ARCH.tar.gz
+sudo rm -rf /opt/nodejs
+sudo mv node-v$NODE_VERSION-linux-$NODE_ARCH /opt/nodejs
+
+sudo ln -sf /opt/nodejs/bin/node /usr/bin/node
+sudo ln -sf /opt/nodejs/bin/npm /usr/bin/npm


### PR DESCRIPTION
Patch for https://github.com/arunoda/meteor-up/issues/25

This implements user control of which node version from the mup.json by nodeVersion parameter.

My reasoning is as follows...
1.  Non opinionated about which version of node to install on setup.  Let user choose.
2.  Allows users to easily use this application to test their app against different versions of node.
3.  Allows ability to upgrade or fallback node versions by re-running setup changing nodeVersion param.
4.  Takes advantage of existing EJS support in nodemiral to create install-node.sh  EJS is rad.
5.  Least number of changes to code base == less disruption to end users.
6.  Fallback install of 0.10.24 if nodeVersion omitted.

Tested on Digital Ocean with 0.10.22, 0.10.23 and leaving nodeVersion out of mup.json
