### PR TITLE
Feature: multiple deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Meteor Up (mup for short) is a command line tool that allows you to deploy any m
 * Support for [`settings.json`](http://docs.meteor.com/#meteor_settings)
 * Password or Private Key(pem) based server authentication
 * Access, logs from the terminal (supports log tailing)
+* Support for multiple meteor deployments
 
 ### Server Configuration
 
@@ -84,6 +85,9 @@ This will create two files in your Meteor Up project directory, which are:
   //install PhantomJS in the server
   "setupPhantom": true,
 
+  //application name
+  "appName": "meteor",
+
   //location of app (local directory)
   "app": "/Users/arunoda/Meteor/my-app",
 
@@ -109,14 +113,14 @@ This will setup the server for the mup deployments. It will take around 2-5 minu
 
 #### Server Setup Details
 
-This is how Meteor Up will configure the server for you. This information will help you to customize server for your needs.
+This is how Meteor Up will configure the server for you based on the given appName or using "meteor" as default appName. This information will help you to customize server for your needs.
 
-* your app is lives in `/opt/meteor/app`
-* mup uses upstart with a config file at `/etc/init/meteor.conf`
-* you can start and stop the app with upstart: `start meteor` and `stop meteor`
+* your app is lives in `/opt/<appName>/app`
+* mup uses upstart with a config file at `/etc/init/<appName>.conf`
+* you can start and stop the app with upstart: `start <appName>` and `stop <appName>`
 * logs are located at: `/var/log/upstart/app.log`
 * MongoDB installed and bind to the local interface (cannot access from the outside)
-* `meteor` is the name of the database
+* `<appName>` is the name of the database
 
 For more information see [`lib/taskLists.js`](https://github.com/arunoda/meteor-up/blob/master/lib/taskLists.js).
 

--- a/example/mup.json
+++ b/example/mup.json
@@ -22,6 +22,9 @@
   //install PhantomJS in the server
   "setupPhantom": true,
 
+  //application name
+  "appName": "meteor",
+
   //location of app (local directory)
   "app": "/path/to/the/app",
 

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -44,7 +44,7 @@ Actions.prototype._createSession = function(config) {
 };
 
 Actions.prototype.setup = function() {
-  var taskList = taskLists.setup(this.config.setupMongo, this.config.setupNode, this.config.nodeVersion, this.config.setupPhantom);
+  var taskList = taskLists.setup(this.config.setupMongo, this.config.setupNode, this.config.nodeVersion, this.config.setupPhantom, this.config.appName);
   taskList.run(this.sessions);
 };
 
@@ -54,6 +54,7 @@ Actions.prototype.deploy = function() {
   var command = format("%s bundle %s", this.config.meteorBinary, bundlePath);
   var options = {cwd: this.config.app};
   var deployCheckWaitTime = this.config.deployCheckWaitTime;
+  var appName = this.config.appName;
 
   console.log('Bundling Started: ' + this.config.app);
   var vars = {
@@ -83,7 +84,7 @@ Actions.prototype.deploy = function() {
       console.error(vars.stderr);
       process.exit(1);
     } else {
-      var taskList = taskLists.deploy(bundlePath, self.config.env, deployCheckWaitTime);
+      var taskList = taskLists.deploy(bundlePath, self.config.env, deployCheckWaitTime, appName);
       taskList.run(self.sessions, afterCompleted);
     }
   });
@@ -103,13 +104,13 @@ Actions.prototype.deploy = function() {
 };
 
 Actions.prototype.reconfig = function() {
-  var taskList = taskLists.reconfig(this.config.env);
+  var taskList = taskLists.reconfig(this.config.env, this.config.appName);
   taskList.run(this.sessions);
 };
 
 Actions.prototype.logs = function() {
   var tailOptions = process.argv.slice(3).join(" ");
-  var command = 'sudo tail ' + tailOptions + ' /var/log/upstart/meteor.log';
+  var command = 'sudo tail ' + tailOptions + ' /var/log/upstart/' + this.config.appName + '.log';
 
   this.sessions.forEach(function(session) {
     var hostPrefix = '[' + session._host + '] ';

--- a/lib/config.js
+++ b/lib/config.js
@@ -44,6 +44,9 @@ exports.read = function() {
       mupJson.setupPhantom = true;
     }
     mupJson.meteorBinary = (mupJson.meteorBinary)? getCanonicalPath(mupJson.meteorBinary): 'meteor';
+    if (typeof mupJson.appName === "undefined") {
+      mupJson.appName = "meteor";
+    }
 
     return mupJson;
   } else {

--- a/lib/taskLists.js
+++ b/lib/taskLists.js
@@ -5,7 +5,7 @@ var path = require('path');
 var SCRIPT_DIR = path.resolve(__dirname, '../scripts');
 var TEMPLATES_DIR = path.resolve(__dirname, '../templates');
 
-exports.setup = function(installMongo, setupNode, nodeVersion, setupPhantom) {
+exports.setup = function(installMongo, setupNode, nodeVersion, setupPhantom, appName) {
   var taskList = nodemiral.taskList('Setting Up');
   
   // Installation
@@ -25,7 +25,10 @@ exports.setup = function(installMongo, setupNode, nodeVersion, setupPhantom) {
   }
 
   taskList.executeScript('setting up environment', {
-    script: path.resolve(SCRIPT_DIR, 'setup-env.sh')
+    script: path.resolve(SCRIPT_DIR, 'setup-env.sh'),
+    vars: {
+      appName: appName
+    }
   });
 
   if(installMongo) {
@@ -42,45 +45,53 @@ exports.setup = function(installMongo, setupNode, nodeVersion, setupPhantom) {
   //Configurations
   taskList.copy('configure upstart', {
     src: path.resolve(TEMPLATES_DIR, 'meteor.conf'),
-    dest: '/etc/init/meteor.conf'
+    dest: '/etc/init/' + appName + '.conf',
+    vars: {
+      appName: appName
+    }
   });
 
   return taskList;
 };
 
-exports.deploy = function(bundlePath, env, deployCheckWaitTime) {
-  var taskList = nodemiral.taskList("Deploying App");
+exports.deploy = function(bundlePath, env, deployCheckWaitTime, appName) {
+  var taskList = nodemiral.taskList("Deploying " + appName + " App");
 
   taskList.copy('uploading bundle', {
     src: bundlePath,
-    dest: '/opt/meteor/tmp/bundle.tar.gz'
+    dest: '/opt/' + appName + '/tmp/bundle.tar.gz'
   });
 
   taskList.copy('setting up env vars', {
     src: path.resolve(TEMPLATES_DIR, 'env.sh'),
-    dest: '/opt/meteor/config/env.sh',
+    dest: '/opt/' + appName + '/config/env.sh',
     vars: {
-      env: env || {}
+      env: env || {},
+      appName: appName
     }
   });
 
   //deploying
   taskList.executeScript('invoking deployment process', {
     script: path.resolve(TEMPLATES_DIR, 'deploy.sh'),
-    vars: {deployCheckWaitTime: deployCheckWaitTime || 10}
+    vars: {
+      deployCheckWaitTime: deployCheckWaitTime || 10,
+      appName: appName
+    }
   });
 
   return taskList;
 };
 
-exports.reconfig = function(env) {
+exports.reconfig = function(env, appName) {
   var taskList = nodemiral.taskList("Updating Configurations");
 
   taskList.copy('setting up env vars', {
     src: path.resolve(TEMPLATES_DIR, 'env.sh'),
-    dest: '/opt/meteor/config/env.sh',
+    dest: '/opt/' + appName + '/config/env.sh',
     vars: {
-      env: env || {}
+      env: env || {},
+      appName: appName
     }
   });
 

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-sudo mkdir -p /opt/meteor/
-sudo mkdir -p /opt/meteor/config
-sudo mkdir -p /opt/meteor/tmp
+sudo mkdir -p /opt/<%= appName %>/
+sudo mkdir -p /opt/<%= appName %>/config
+sudo mkdir -p /opt/<%= appName %>/tmp
 
-sudo chown $USER /opt/meteor -R
+sudo chown $USER /opt/<%= appName %> -R
 sudo chown $USER /etc/init
 sudo chown $USER /etc/
 

--- a/templates/deploy.sh
+++ b/templates/deploy.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 set -e
 
-cd /opt/meteor/tmp
+cd /opt/<%= appName %>/tmp
 sudo rm -rf bundle
 sudo tar xvzf bundle.tar.gz > /dev/null
 cd bundle/programs/server
 sudo npm install fibers
 
-cd /opt/meteor/
+cd /opt/<%= appName %>/
 
 # remove old app, if exists
 if [ -d old_app ]; then
@@ -22,15 +22,15 @@ fi
 sudo mv tmp/bundle app
 
 # restart app
-sudo stop meteor || :
-sudo start meteor || :
+sudo stop <%= appName %> || :
+sudo start <%= appName %> || :
 
 revert_app (){
   if [[ -d old_app ]]; then
     sudo rm -rf app
     sudo mv old_app app
-    sudo stop meteor || :
-    sudo start meteor || :
+    sudo stop <%= appName %> || :
+    sudo start <%= appName %> || :
 
     echo "reverted back to the previous version due to the latest version didn't pick up!" 1>&2
     exit 1
@@ -42,7 +42,7 @@ revert_app (){
 
 #wait and check
 echo "wait for mongo(5 minutes) to initialize"
-. /opt/meteor/config/env.sh
+. /opt/<%= appName %>/config/env.sh
 wait-for-mongo $MONGO_URL 300000
 
 echo "waiting for <%= deployCheckWaitTime %> secs while app is booting up"

--- a/templates/env.sh
+++ b/templates/env.sh
@@ -1,5 +1,5 @@
 export PORT=80
-export MONGO_URL=mongodb://127.0.0.1/meteor
+export MONGO_URL=mongodb://127.0.0.1/<%= appName %>
 export ROOT_URL=http://localhost
 
 #it is possible to override above env-vars from the user-provided values

--- a/templates/meteor.conf
+++ b/templates/meteor.conf
@@ -11,7 +11,7 @@ limit nofile 65536 65536
 
 script
     
-    cd /opt/meteor
+    cd /opt/<%= appName %>
 
     ##add custom enviromntal variables
     if [ -f config/env.sh ]; then

--- a/templates/meteor.conf
+++ b/templates/meteor.conf
@@ -1,5 +1,5 @@
 #!upstart
-description "MeteorUp"
+description "MeteorUp - <%= appName %>"
 author      "Arunoda Susiripala, <arunoda.susiripala@gmail.com>"
 
 start on runlevel [2345]


### PR DESCRIPTION
Basically "meteor" as application name is now configurable through an "appName" variable on mup.json.
for example: if "appName" has "todo" as value, we would end up with:
application deployed at: /opt/todo/app
upstart config file: /etc/init/todo.conf so we can do start todo | stop todo
default mongo database: todo

If the "appName" attribute is not set, then the default value would be "meteor" leaving the functionality as it was before.
