### PR TITLE
Show the app error in logs when reverting app

### DIFF
--- a/templates/deploy.sh
+++ b/templates/deploy.sh
@@ -37,6 +37,8 @@ sudo stop <%= appName %> || :
 sudo start <%= appName %> || :
 
 revert_app (){
+  echo "'<%= appName %>' Application log:" 1>&2
+  sudo tail -c 900 /var/log/upstart/<%= appName %>.log 1>&2
   if [[ -d old_app ]]; then
     sudo rm -rf app
     sudo mv old_app app


### PR DESCRIPTION
The error message takes only the last 1000 characters of stderr so I tailed 900 charts to give room for the"appName Application log" line.

Do we want to show the last X lines of stderr, stdout instead of the last 1000 chars?

If so let me know and I can send another pull request.
