### PR TITLE
[deps] Default to node 10.26 which is the minimum required by latest meteor

### DIFF
--- a/example/mup.json
+++ b/example/mup.json
@@ -16,8 +16,8 @@
   // WARNING: Node.js is required! Only skip if you already have Node.js installed on server.
   "setupNode": true,
 
-  // WARNING: If nodeVersion omitted will setup 0.10.25 by default. Do not use v, only version number.
-  "nodeVersion": "0.10.25",
+  // WARNING: If nodeVersion omitted will setup 0.10.26 by default. Do not use v, only version number.
+  "nodeVersion": "0.10.26",
 
   // Install PhantomJS in the server
   "setupPhantom": true,


### PR DESCRIPTION
Addresses the issue of the default node version in `mup.json` being lower than the minimum required by the newest builds of meteor.

This was also mentioned in issue #58
