### PR TITLE
Support deploying Meteor 0.9.0 bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Meteor Up (mup for short) is a command line tool that allows you to deploy any [
 - [Accessing the Database](#accessing-the-database)
 - [Multiple Deployments](#multiple-deployments)
 - [Multiple OS Support](#multiple-os-support)
-- [Binary NPM Modules](#binary-npm-modules)
 - [Updating](#updating)
 - [Troubleshooting](#troubleshooting)
 
@@ -240,24 +239,6 @@ We need to have two separate Meteor Up projects. For that, create two directorie
 In the staging `mup.json`, add a field called `appName` with the value `staging`. You can add any name you prefer instead of `staging`. Since we are running our staging app on port 8000, add an environment variable called `PORT` with the value 8000.
 
 Now setup both projects and deploy as you need.
-
-### Binary NPM Modules
-
-If you are using binary npm modules either with meteor-npm or with some other package you can't deploy and run your app by default. That's because binaries in the bundle are not compatible with your deployment environment.
-
-So, you need to specify in `mup.json` the binary modules and which packages they are in.
-
-~~~json
-{
-  ...
-
-  "binaryNpmModules": {
-    "meteor-package-name": ["npm-module1", "npm-module2"]
-  }
-
-  ...
-}
-~~~
 
 ### Updating
 

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -109,7 +109,7 @@ Actions.prototype.deploy = function() {
         var sessionsInfo = self.sessionsMap[os];
         var taskList = sessionsInfo.taskListsBuilder.deploy(
           bundlePath, self.config.env,
-          deployCheckWaitTime, appName, self.config.binaryNpmModules);
+          deployCheckWaitTime, appName);
         taskList.run(sessionsInfo.sessions);
       }
     }

--- a/lib/config.js
+++ b/lib/config.js
@@ -52,8 +52,6 @@ exports.read = function() {
       mupJson.appName = "meteor";
     }
 
-    mupJson.binaryNpmModules = mupJson.binaryNpmModules || {};
-
     return mupJson;
   } else {
     console.error('mup.json file does not exist!'.red.bold);

--- a/lib/taskLists/linux.js
+++ b/lib/taskLists/linux.js
@@ -54,7 +54,7 @@ exports.setup = function(installMongo, setupNode, nodeVersion, setupPhantom, app
   return taskList;
 };
 
-exports.deploy = function(bundlePath, env, deployCheckWaitTime, appName, binaryNpmModules) {
+exports.deploy = function(bundlePath, env, deployCheckWaitTime, appName) {
   var taskList = nodemiral.taskList("Deploy app '" + appName + "' (linux)");
 
   taskList.copy('Uploading bundle', {
@@ -76,8 +76,7 @@ exports.deploy = function(bundlePath, env, deployCheckWaitTime, appName, binaryN
     script: path.resolve(TEMPLATES_DIR, 'deploy.sh'),
     vars: {
       deployCheckWaitTime: deployCheckWaitTime || 10,
-      appName: appName,
-      binaryNpmModules: binaryNpmModules
+      appName: appName
     }
   });
 

--- a/lib/taskLists/sunos.js
+++ b/lib/taskLists/sunos.js
@@ -49,7 +49,7 @@ exports.setup = function(installMongo, setupNode, nodeVersion, setupPhantom, app
   return taskList;
 };
 
-exports.deploy = function(bundlePath, env, deployCheckWaitTime, appName, binaryNpmModules) {
+exports.deploy = function(bundlePath, env, deployCheckWaitTime, appName) {
   var taskList = nodemiral.taskList("Deploy app '" + appName + "' (sunos)");
 
   taskList.copy('Uploading bundle', {
@@ -64,8 +64,7 @@ exports.deploy = function(bundlePath, env, deployCheckWaitTime, appName, binaryN
     script: path.resolve(TEMPLATES_DIR, 'deploy.sh'),
     vars: {
       deployCheckWaitTime: deployCheckWaitTime || 10,
-      appName: appName,
-      binaryNpmModules: binaryNpmModules
+      appName: appName
     }
   });
 

--- a/templates/linux/deploy.sh
+++ b/templates/linux/deploy.sh
@@ -10,14 +10,7 @@ sudo tar xvzf bundle.tar.gz > /dev/null
 
 # rebuilding fibers
 cd ${BUNDLE_DIR}/programs/server
-sudo npm install fibers
-sudo npm install bcrypt
-
-# rebuilding other modules inside packages
-<% for(var packageName in binaryNpmModules) { %>
-  cd ${BUNDLE_DIR}/programs/server/npm/<%= packageName %>/main
-  sudo npm rebuild <%= binaryNpmModules[packageName].join(' ') %>
-<% } %>
+sudo npm install
 
 cd /opt/<%= appName %>/
 

--- a/templates/sunos/deploy.sh
+++ b/templates/sunos/deploy.sh
@@ -10,14 +10,7 @@ sudo tar xvzf bundle.tar.gz > /dev/null
 
 # rebuilding fibers
 cd ${BUNDLE_DIR}/programs/server
-sudo npm install fibers
-sudo npm install bcrypt
-
-# rebuilding other modules inside packages
-<% for(var packageName in binaryNpmModules) { %>
-  cd ${BUNDLE_DIR}/programs/server/npm/<%= packageName %>/main
-  sudo npm rebuild <%= binaryNpmModules[packageName].join(' ') %>
-<% } %>
+sudo npm install
 
 cd /opt/<%= appName %>/
 


### PR DESCRIPTION
I had problems deploy Meteor 0.9.0 release candidates, so in order to fix it, I changed the deploy scripts slightly.

This PR should also fix the need to specify Binary NPM Modules.
