### PR TITLE
Revert "Kill Meteor with SIGHUP"

### DIFF
--- a/templates/linux/meteor.conf
+++ b/templates/linux/meteor.conf
@@ -5,7 +5,6 @@ author      "Arunoda Susiripala, <arunoda.susiripala@gmail.com>"
 start on runlevel [2345]
 stop on runlevel [06]
 
-kill signal SIGHUP
 respawn
 
 limit nofile 65536 65536


### PR DESCRIPTION
This reverts commit 39b9dffcd1dc81bcd93a8f523b982868eeda9081, merged in PR #209.

This caused issue #164 to recur in otherwise nominally functional mup-deployed Meteor apps. I think SIGHUP doesn't properly kill `forever`.

See also: https://groups.google.com/forum/#!topic/meteor-talk/Dmlg8-2mXWk
