### PR TITLE
[DEPLOY] Fixed deploy from my Jenkins slave

### DIFF
--- a/templates/linux/deploy.sh
+++ b/templates/linux/deploy.sh
@@ -58,6 +58,7 @@ BUNDLE_DIR=${TMP_DIR}/bundle
 cd ${TMP_DIR}
 sudo rm -rf bundle
 sudo tar xvzf bundle.tar.gz > /dev/null
+sudo chown -R ${USER} ${BUNDLE_DIR}
 
 # rebuilding fibers
 cd ${BUNDLE_DIR}/programs/server


### PR DESCRIPTION
Adding a change owner of the bundle folder after it's extracted when running from Jenkins Slave that use a user ID that does not exist on the target server, a permission denied will occurs. Setting the permission correctly after the extract fix this.
