### PR TITLE
deployPath can now be set in config to override the default '/opt'

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,14 @@ This will create two files in your Meteor Up project directory:
   // Application name (no spaces).
   "appName": "meteor",
 
-  // Location of app (local directory). This can reference '~' as the users home directory.
-  // i.e., "app": "~/Meteor/my-app",
-  // This is the same as the line below.
-  "app": "/Users/arunoda/Meteor/my-app",
+  // Deploy path on the servers (same path for all servers).
+  // If not defined it defaults to '/opt'. Make sure you have no trailing slash !
+  // "deployPath": "/srv/meteor",
+
+  // Location of the app directory on your own machine (local).
+  // This can reference '~' as the users home directory.
+  // If omitted, it will use the current path where you execute 'mup deploy'
+  // "app": "/Users/arunoda/Meteor/my-app",
 
   // Configure environment
   "env": {

--- a/example/mup.json
+++ b/example/mup.json
@@ -25,8 +25,13 @@
   // Application name (No spaces)
   "appName": "meteor",
 
-  // Location of app (local directory)
-  "app": "/path/to/the/app",
+  // Deploy path on the servers (same path for all servers).
+  // If not defined it defaults to '/opt'. Make sure you have no trailing slash !
+  // "deployPath": "/srv/meteor",
+
+  // Location of the app directory on your own machine (local).
+  // If omitted, it will use the current path where you execute 'mup deploy'
+  // "app": "/path/to/the/app",
 
   // Configure environment
   "env": {

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -83,7 +83,7 @@ Actions.prototype.setup = function() {
     var sessionsInfo = self.sessionsMap[os];
     var taskList = sessionsInfo.taskListsBuilder.setup(
       self.config.setupMongo, self.config.setupNode, self.config.nodeVersion,
-      self.config.setupPhantom, self.config.appName);
+      self.config.setupPhantom, self.config.appName, self.config.deployPath);
     taskList.run(sessionsInfo.sessions);
   }
 };
@@ -105,6 +105,7 @@ Actions.prototype.deploy = function() {
   var buildScript = path.resolve(__dirname, 'build.sh');
   var deployCheckWaitTime = this.config.deployCheckWaitTime;
   var appName = this.config.appName;
+  var deployPath = this.config.deployPath;
 
   console.log('Building Started: ' + this.config.app);
   buildApp(buildScript, options, function(err) {
@@ -115,7 +116,7 @@ Actions.prototype.deploy = function() {
         var sessionsInfo = self.sessionsMap[os];
         var taskList = sessionsInfo.taskListsBuilder.deploy(
           bundlePath, self.config.env,
-          deployCheckWaitTime, appName);
+          deployCheckWaitTime, appName, deployPath);
         taskList.run(sessionsInfo.sessions, afterCompleted);
       }
     }

--- a/lib/config.js
+++ b/lib/config.js
@@ -22,7 +22,7 @@ exports.read = function() {
         } else if(!server.password && !server.pem) {
           mupErrorLog('Server password or pem does not exist');
         } else if(!mupJson.app) {
-          mupErrorLog('Path to app does not exist');
+          mupJson.app = process.env.PWD;
         }
 
         server.os = server.os || "linux";
@@ -50,6 +50,9 @@ exports.read = function() {
     mupJson.meteorBinary = (mupJson.meteorBinary) ? getCanonicalPath(mupJson.meteorBinary) : 'meteor';
     if(typeof mupJson.appName === "undefined") {
       mupJson.appName = "meteor";
+    }
+    if(typeof mupJson.deployPath === "undefined") {
+      mupJson.deployPath = "/opt";
     }
 
     return mupJson;

--- a/lib/taskLists/linux.js
+++ b/lib/taskLists/linux.js
@@ -5,7 +5,7 @@ var path = require('path');
 var SCRIPT_DIR = path.resolve(__dirname, '../../scripts/linux');
 var TEMPLATES_DIR = path.resolve(__dirname, '../../templates/linux');
 
-exports.setup = function(installMongo, setupNode, nodeVersion, setupPhantom, appName) {
+exports.setup = function(installMongo, setupNode, nodeVersion, setupPhantom, appName, deployPath) {
   var taskList = nodemiral.taskList('Setup (linux)');
 
   // Installation
@@ -27,7 +27,8 @@ exports.setup = function(installMongo, setupNode, nodeVersion, setupPhantom, app
   taskList.executeScript('Setting up Environment', {
     script: path.resolve(SCRIPT_DIR, 'setup-env.sh'),
     vars: {
-      appName: appName
+      appName: appName,
+      deployPath: deployPath
     }
   });
 
@@ -47,27 +48,29 @@ exports.setup = function(installMongo, setupNode, nodeVersion, setupPhantom, app
     src: path.resolve(TEMPLATES_DIR, 'meteor.conf'),
     dest: '/etc/init/' + appName + '.conf',
     vars: {
-      appName: appName
+      appName: appName,
+      deployPath: deployPath
     }
   });
 
   return taskList;
 };
 
-exports.deploy = function(bundlePath, env, deployCheckWaitTime, appName) {
-  var taskList = nodemiral.taskList("Deploy app '" + appName + "' (linux)");
+exports.deploy = function(bundlePath, env, deployCheckWaitTime, appName, deployPath) {
+  var taskList = nodemiral.taskList("Deploy app '" + appName + "' to " + deployPath + " (linux)");
 
   taskList.copy('Uploading bundle', {
     src: bundlePath,
-    dest: '/opt/' + appName + '/tmp/bundle.tar.gz'
+    dest: deployPath + '/' + appName + '/tmp/bundle.tar.gz'
   });
 
   taskList.copy('Setting up Environment Variables', {
     src: path.resolve(TEMPLATES_DIR, 'env.sh'),
-    dest: '/opt/' + appName + '/config/env.sh',
+    dest: deployPath + '/' + appName + '/config/env.sh',
     vars: {
       env: env || {},
-      appName: appName
+      appName: appName,
+      deployPath: deployPath
     }
   });
 
@@ -76,22 +79,24 @@ exports.deploy = function(bundlePath, env, deployCheckWaitTime, appName) {
     script: path.resolve(TEMPLATES_DIR, 'deploy.sh'),
     vars: {
       deployCheckWaitTime: deployCheckWaitTime || 10,
-      appName: appName
+      appName: appName,
+      deployPath: deployPath
     }
   });
 
   return taskList;
 };
 
-exports.reconfig = function(env, appName) {
+exports.reconfig = function(env, appName, deployPath) {
   var taskList = nodemiral.taskList("Updating configurations (linux)");
 
   taskList.copy('Setting up Environment Variables', {
     src: path.resolve(TEMPLATES_DIR, 'env.sh'),
-    dest: '/opt/' + appName + '/config/env.sh',
+    dest: deployPath + '/' + appName + '/config/env.sh',
     vars: {
       env: env || {},
-      appName: appName
+      appName: appName,
+      deployPath: deployPath
     }
   });
 

--- a/lib/taskLists/sunos.js
+++ b/lib/taskLists/sunos.js
@@ -5,7 +5,7 @@ var path = require('path');
 var SCRIPT_DIR = path.resolve(__dirname, '../../scripts/sunos');
 var TEMPLATES_DIR = path.resolve(__dirname, '../../templates/sunos');
 
-exports.setup = function(installMongo, setupNode, nodeVersion, setupPhantom, appName) {
+exports.setup = function(installMongo, setupNode, nodeVersion, setupPhantom, appName, deployPath) {
   var taskList = nodemiral.taskList('Setup (sunos)');
 
   // Installation
@@ -21,24 +21,27 @@ exports.setup = function(installMongo, setupNode, nodeVersion, setupPhantom, app
   taskList.executeScript('Setting up Environment', {
     script: path.resolve(SCRIPT_DIR, 'setup-env.sh'),
     vars: {
-      appName: appName
+      appName: appName,
+      deployPath: deployPath
     }
   });
 
   taskList.copy('Setting up Running Script', {
     src: path.resolve(TEMPLATES_DIR, 'run.sh'),
-    dest: '/opt/' + appName + '/run.sh',
+    dest: deployPath +'/' + appName + '/run.sh',
     vars: {
-      appName: appName
+      appName: appName,
+      deployPath: deployPath
     }
   });
 
-  var serviceManifestDest = '/opt/' + appName + '/config/service-manifest.xml';
+  var serviceManifestDest = deployPath + '/' + appName + '/config/service-manifest.xml';
   taskList.copy('Copying SMF Manifest', {
     src: path.resolve(TEMPLATES_DIR, 'service-manifest.xml'),
     dest: serviceManifestDest,
     vars: {
-      appName: appName
+      appName: appName,
+      deployPath: deployPath
     }
   });
 
@@ -49,32 +52,33 @@ exports.setup = function(installMongo, setupNode, nodeVersion, setupPhantom, app
   return taskList;
 };
 
-exports.deploy = function(bundlePath, env, deployCheckWaitTime, appName) {
+exports.deploy = function(bundlePath, env, deployCheckWaitTime, appName, deployPath) {
   var taskList = nodemiral.taskList("Deploy app '" + appName + "' (sunos)");
 
   taskList.copy('Uploading bundle', {
     src: bundlePath,
-    dest: '/opt/' + appName + '/tmp/bundle.tar.gz'
+    dest: deployPath + '/' + appName + '/tmp/bundle.tar.gz'
   });
 
-  reconfig(taskList, appName, env);
+  reconfig(taskList, appName, deployPath, env);
 
   // deploying
   taskList.executeScript('Invoking deployment process', {
     script: path.resolve(TEMPLATES_DIR, 'deploy.sh'),
     vars: {
       deployCheckWaitTime: deployCheckWaitTime || 10,
-      appName: appName
+      appName: appName,
+      deployPath: deployPath
     }
   });
 
   return taskList;
 };
 
-exports.reconfig = function(env, appName) {
+exports.reconfig = function(env, appName, deployPath) {
   var taskList = nodemiral.taskList("Updating configurations (sunos)");
 
-  reconfig(taskList, appName, env);
+  reconfig(taskList, appName, deployPath, env);
 
   //deploying
   taskList.execute('Restarting app', {
@@ -85,13 +89,14 @@ exports.reconfig = function(env, appName) {
 };
 
 
-function reconfig(taskList, appName, env) {
+function reconfig(taskList, appName, deployPath, env) {
   taskList.copy('Setting up Environment Variables', {
     src: path.resolve(TEMPLATES_DIR, 'env.sh'),
-    dest: '/opt/' + appName + '/config/env.sh',
+    dest: deployPath + '/' + appName + '/config/env.sh',
     vars: {
       env: env || {},
-      appName: appName
+      appName: appName,
+      deployPath: deployPath
     }
   });
 }

--- a/scripts/linux/setup-env.sh
+++ b/scripts/linux/setup-env.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-sudo mkdir -p /opt/<%= appName %>/
-sudo mkdir -p /opt/<%= appName %>/config
-sudo mkdir -p /opt/<%= appName %>/tmp
+sudo mkdir -p <%= deployPath %>/<%= appName %>/
+sudo mkdir -p <%= deployPath %>/<%= appName %>/config
+sudo mkdir -p <%= deployPath %>/<%= appName %>/tmp
 
-sudo chown ${USER} /opt/<%= appName %> -R
+sudo chown ${USER} <%= deployPath %>/<%= appName %> -R
 sudo chown ${USER} /etc/init
 sudo chown ${USER} /etc/
 

--- a/scripts/sunos/setup-env.sh
+++ b/scripts/sunos/setup-env.sh
@@ -3,11 +3,11 @@
 # install make and other build tool
 sudo pkgin -y install build-essential
 
-sudo mkdir -p /opt/<%= appName %>/
-sudo mkdir -p /opt/<%= appName %>/config
-sudo mkdir -p /opt/<%= appName %>/tmp
+sudo mkdir -p <%= deployPath %>/<%= appName %>/
+sudo mkdir -p <%= deployPath %>/<%= appName %>/config
+sudo mkdir -p <%= deployPath %>/<%= appName %>/tmp
 
-sudo chown ${USER} /opt/<%= appName %> -R
+sudo chown ${USER} <%= deployPath %>/<%= appName %> -R
 sudo chown ${USER} /etc/init
 sudo chown ${USER} /etc/
 

--- a/templates/linux/deploy.sh
+++ b/templates/linux/deploy.sh
@@ -52,7 +52,7 @@ revert_app (){
 # logic
 set -e
 
-TMP_DIR=/opt/<%= appName %>/tmp
+TMP_DIR=<%= deployPath %>/<%= appName %>/tmp
 BUNDLE_DIR=${TMP_DIR}/bundle
 
 cd ${TMP_DIR}
@@ -84,7 +84,7 @@ else
   sudo npm install bcrypt
 fi
 
-cd /opt/<%= appName %>/
+cd <%= deployPath %>/<%= appName %>/
 
 # remove old app, if it exists
 if [ -d old_app ]; then
@@ -100,7 +100,7 @@ sudo mv tmp/bundle app
 
 #wait and check
 echo "Waiting for MongoDB to initialize. (5 minutes)"
-. /opt/<%= appName %>/config/env.sh
+. <%= deployPath %>/<%= appName %>/config/env.sh
 wait-for-mongo ${MONGO_URL} 300000
 
 # restart app

--- a/templates/linux/meteor.conf
+++ b/templates/linux/meteor.conf
@@ -11,7 +11,7 @@ limit nofile 65536 65536
 
 script
 
-    cd /opt/<%= appName %>
+    cd <%= deployPath %>/<%= appName %>
 
     ##add userdown config
     export USERDOWN_UID=meteoruser USERDOWN_GID=meteoruser

--- a/templates/sunos/deploy.sh
+++ b/templates/sunos/deploy.sh
@@ -47,7 +47,7 @@ revert_app (){
 # logic
 set -e
 
-TMP_DIR=/opt/<%= appName %>/tmp
+TMP_DIR=<%= deployPath %>/<%= appName %>/tmp
 BUNDLE_DIR=${TMP_DIR}/bundle
 
 cd ${TMP_DIR}
@@ -69,7 +69,7 @@ else
   sudo npm install bcrypt
 fi
 
-cd /opt/<%= appName %>/
+cd <%= deployPath %>/<%= appName %>/
 
 # remove old app, if it exists
 if [ -d old_app ]; then
@@ -85,7 +85,7 @@ sudo mv tmp/bundle app
 
 #wait and check
 echo "Waiting for MongoDB to initialize. (5 minutes)"
-. /opt/<%= appName %>/config/env.sh
+. <%= deployPath %>/<%= appName %>/config/env.sh
 wait-for-mongo ${MONGO_URL} 300000
 
 # restart app

--- a/templates/sunos/service-manifest.xml
+++ b/templates/sunos/service-manifest.xml
@@ -15,7 +15,7 @@
       <service_fmri value="svc:/system/filesystem/local"/>
     </dependency>
 
-    <method_context working_directory="/opt/<%= appName %>">
+    <method_context working_directory="<%= deployPath %>/<%= appName %>">
       <method_credential user="root" group="root" privileges='basic,net_privaddr'  />
       <method_environment>
         <envvar name="PATH" value="/opt/local/bin:/usr/local/bin:/usr/bin:/usr/sbin:/bin"/>


### PR DESCRIPTION
Added a new option to the config : deployPath , which will allow deploying to other directories then /opt, if omitted it defaults to /opt for backwards compatibility

You can now omit the config setting : "app", if so, it will use the current PWD where you launched 'mup setup|deploy', this is more team friendly as everyone uses their own directory structure.
