### PR TITLE
Nginx Multiple App Hosting on Single Server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Meteor Up (mup for short) is a command line tool that allows you to deploy any [
 
 - [Features](#features)
 - [Server Configuration](#server-configuration)
+- [Nginx Multiple App Hosting](#server-nginx)
 - [Installation](#installation)
 - [Creating a Meteor Up Project](#creating-a-meteor-up-project)
 - [Example File](#example-file)
@@ -48,6 +49,14 @@ Meteor Up (mup for short) is a command line tool that allows you to deploy any [
 * Revert to the previous version, if the deployment failed
 * Secured MongoDB Installation (Optional)
 * Pre-Installed PhantomJS (Optional)
+
+### Server Nginx
+
+* Host multiple applications on a single server
+* Define a unique port and ROOT_URL for each instance and Nginx will proxy forward accordingly
+* Prevents multiple deployments of the same port on a single server
+* add `setupNginx:true` to `mup.json` and specify a `PORT` and `ROOT_URL` in the environment variables
+* Provide a unique `appName` for each app. This will install it into its own folder and own upstart on the server.
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ This will create two files in your Meteor Up project directory:
   // Install PhantomJS on the server
   "setupPhantom": true,
 
+  // Install Nginx on the server (Requires a unique PORT and ROOT_URL in the environment settings
+  // Note: Port must not be 80 as Nginx will proxy_forward to port 80 per ROOT_URL (e.g. 3000, 3001, 3002, etc)
+  "setupNginx": true,
+
   // Application name (no spaces).
   "appName": "meteor",
 

--- a/README.md
+++ b/README.md
@@ -267,6 +267,33 @@ Now setup both projects and deploy as you need.
 
 ### SSL Support
 
+Meteor Up now supports both stud and nginx SSL termination for your app.
+
+#### Nginx SSL Configuration
+
+* Place your certficate and private key files in a folder (suggestion is to use `.ssl` in your project folder)
+* Add the following lines to your `mup.json` file:
+
+~~~js
+{
+  ...
+
+  "ssl": {
+    "pem": "./.ssl/cert.pem",
+    "key": "./.ssl/private.key"
+  }
+
+  ...
+}
+~~~
+
+* Run `mup deploy` on a preconfigured Nginx+MUP host.
+* you will now be able to browse to your website address and it will automatcially promote it to SSL.
+
+**Note:** Be sure to add the `https://` path to your `ROOT_URL` enviromnent variable also!
+
+#### Stud SSL Configuration
+
 Meteor Up has the built in SSL support. It uses [stud](https://github.com/bumptech/stud) SSL terminator for that. First you need to get a SSL certificate from some provider. This is how to do that:
 
 * [First you need to generate a CSR file and the private key](http://www.rackspace.com/knowledge_center/article/generate-a-csr-with-openssl)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Meteor Up (mup for short) is a command line tool that allows you to deploy any [
 * Prevents multiple deployments of the same port on a single server
 * add `setupNginx:true` to `mup.json` and specify a `PORT` and `ROOT_URL` in the environment variables
 * Provide a unique `appName` for each app. This will install it into its own folder and own upstart on the server.
+* Serve files from the `/public` folder directly through Nginx with caching instead of Meteor directly `(jpg|jpeg|png|gif|mp3|ico|pdf)`
 
 ### Installation
 

--- a/example/mup.json
+++ b/example/mup.json
@@ -22,11 +22,15 @@
   // Install PhantomJS in the server
   "setupPhantom": true,
 
+  // Install Nginx on the server (Requires a unique PORT and ROOT_URL in the environment settings
+  // Note: Port must not be 80 as Nginx will proxy_forward to port 80 per ROOT_URL (e.g. 3000, 3001, 3002, etc)
+  "setupNginx": false,
+
   // Application name (No spaces)
   "appName": "meteor",
 
   // Location of app (local directory)
-  "app": "/path/to/the/app",
+  "app": ".",
 
   // Configure environment
   "env": {

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -106,6 +106,7 @@ Actions.prototype.deploy = function() {
   var deployCheckWaitTime = this.config.deployCheckWaitTime;
   var appName = this.config.appName;
   var setupNginx = this.config.setupNginx || false;
+  var ssl = this.config.ssl || false;
 
   console.log('Building Started: ' + this.config.app);
   buildApp(buildScript, options, function(err) {
@@ -118,7 +119,7 @@ Actions.prototype.deploy = function() {
           var env = _.extend({}, self.config.env, session._serverConfig.env);
           var taskList = sessionsInfo.taskListsBuilder.deploy(
             bundlePath, env,
-            deployCheckWaitTime, appName, setupNginx);
+            deployCheckWaitTime, appName, setupNginx, ssl);
           taskList.run(session, afterCompleted);
         });
       }

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -105,6 +105,7 @@ Actions.prototype.deploy = function() {
   var buildScript = path.resolve(__dirname, 'build.sh');
   var deployCheckWaitTime = this.config.deployCheckWaitTime;
   var appName = this.config.appName;
+  var setupNginx = this.config.setupNginx || false;
 
   console.log('Building Started: ' + this.config.app);
   buildApp(buildScript, options, function(err) {
@@ -117,7 +118,7 @@ Actions.prototype.deploy = function() {
           var env = _.extend({}, self.config.env, session._serverConfig.env);
           var taskList = sessionsInfo.taskListsBuilder.deploy(
             bundlePath, env,
-            deployCheckWaitTime, appName);
+            deployCheckWaitTime, appName, setupNginx);
           taskList.run(session, afterCompleted);
         });
       }
@@ -136,7 +137,7 @@ Actions.prototype.reconfig = function() {
     sessionsInfo.sessions.forEach(function(session) {
       var env = _.extend({}, self.config.env, session._serverConfig.env);
       var taskList = sessionsInfo.taskListsBuilder.reconfig(
-        env, self.config.appName);
+        env, self.config.appName, self.config.setupNginx);
       taskList.run(session);
     });
   }

--- a/lib/config.js
+++ b/lib/config.js
@@ -73,6 +73,10 @@ exports.read = function() {
     mupJson.app = rewriteHome(mupJson.app);
 
     if(mupJson.ssl) {
+      
+      if (mupJson.setupNginx)
+        mupErrorLog('Cannot configure SSL support and Nginx together');
+
       mupJson.ssl.backendPort = mupJson.ssl.backendPort || 80;
       mupJson.ssl.pem = path.resolve(rewriteHome(mupJson.ssl.pem));
       if(!fs.existsSync(mupJson.ssl.pem)) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -20,9 +20,20 @@ exports.read = function() {
     if(typeof mupJson.setupPhantom === "undefined") {
       mupJson.setupPhantom = true;
     }
+    if(typeof mupJson.setupNginx === "undefined") {
+      mupJson.setupNginx = false;
+    }
     mupJson.meteorBinary = (mupJson.meteorBinary) ? getCanonicalPath(mupJson.meteorBinary) : 'meteor';
     if(typeof mupJson.appName === "undefined") {
       mupJson.appName = "meteor";
+    }
+
+    // make sure a PORT and ROOT_URL is specified for Nginx config
+    if (mupJson.setupNginx) {
+      if (!mupJson.env['PORT'])
+        mupErrorLog('PORT environment variable must be specified for a Nginx deploy');
+      if (!mupJson.env['ROOT_URL'])
+        mupErrorLog('ROOT_URL environment variable must be specified for a Nginx deploy');
     }
 
     //validating servers
@@ -54,6 +65,7 @@ exports.read = function() {
           format("http://%s:%s", server.host, mupJson.env['PORT'] || 80);
         server.env['CLUSTER_ENDPOINT_URL'] =
           server.env['CLUSTER_ENDPOINT_URL'] || defaultEndpointUrl;
+
       });
     }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -73,14 +73,22 @@ exports.read = function() {
     mupJson.app = rewriteHome(mupJson.app);
 
     if(mupJson.ssl) {
-      
-      if (mupJson.setupNginx)
-        mupErrorLog('Cannot configure SSL support and Nginx together');
 
-      mupJson.ssl.backendPort = mupJson.ssl.backendPort || 80;
-      mupJson.ssl.pem = path.resolve(rewriteHome(mupJson.ssl.pem));
-      if(!fs.existsSync(mupJson.ssl.pem)) {
-        mupErrorLog('SSL pem file does not exist');
+      if (mupJson.setupNginx) {
+        mupJson.ssl.pem = path.resolve(rewriteHome(mupJson.ssl.pem));
+        if(!fs.existsSync(mupJson.ssl.pem)) {
+          mupErrorLog('Nginx SSL - pem file does not exist');
+        }
+        mupJson.ssl.key = path.resolve(rewriteHome(mupJson.ssl.key));
+        if(!fs.existsSync(mupJson.ssl.key)) {
+          mupErrorLog('Nginx SSL - key file does not exist');
+        }
+      } else {
+        mupJson.ssl.backendPort = mupJson.ssl.backendPort || 80;
+        mupJson.ssl.pem = path.resolve(rewriteHome(mupJson.ssl.pem));
+        if(!fs.existsSync(mupJson.ssl.pem)) {
+          mupErrorLog('stud SSL - pem file does not exist');
+        }
       }
     }
 

--- a/lib/taskLists/linux.js
+++ b/lib/taskLists/linux.js
@@ -25,6 +25,18 @@ exports.setup = function(config) {
     });
   }
 
+  if(config.setupNginx) {
+    taskList.executeScript('Installing Nginx', {
+      script: path.resolve(SCRIPT_DIR, 'install-nginx.sh')
+    });
+
+    taskList.copy('Configuring Nginx', {
+      src: path.resolve(TEMPLATES_DIR, 'index.html'),
+      dest: '/usr/share/nginx/html/index.html'
+    });
+
+  }
+
   taskList.executeScript('Setting up Environment', {
     script: path.resolve(SCRIPT_DIR, 'setup-env.sh'),
     vars: {
@@ -60,8 +72,29 @@ exports.setup = function(config) {
   return taskList;
 };
 
-exports.deploy = function(bundlePath, env, deployCheckWaitTime, appName) {
+exports.deploy = function(bundlePath, env, deployCheckWaitTime, appName, setupNginx) {
   var taskList = nodemiral.taskList("Deploy app '" + appName + "' (linux)");
+
+  if (setupNginx) {
+    //configure nginx
+    taskList.copy('Configuring Nginx (App Instance)', {
+      src: path.resolve(TEMPLATES_DIR, 'nginx.conf'),
+      dest: '/etc/nginx/sites-available/' + appName + '.conf',
+      vars: {
+        appPort: env['PORT'],
+        appRoot: env['ROOT_URL'].replace(/.*?:\/\//g, "")
+      }
+    });
+
+    taskList.executeScript('Configuring Nginx (Enabling Site)', {
+      script: path.resolve(SCRIPT_DIR, 'setup-nginx.sh'),
+      vars: {
+        appPort: env['PORT'],
+        appName: appName
+      }
+    });
+
+  }
 
   taskList.copy('Uploading bundle', {
     src: bundlePath,
@@ -89,7 +122,7 @@ exports.deploy = function(bundlePath, env, deployCheckWaitTime, appName) {
   return taskList;
 };
 
-exports.reconfig = function(env, appName) {
+exports.reconfig = function(env, appName, setupNginx) {
   var taskList = nodemiral.taskList("Updating configurations (linux)");
 
   taskList.copy('Setting up Environment Variables', {
@@ -105,6 +138,26 @@ exports.reconfig = function(env, appName) {
   taskList.execute('Restarting app', {
     command: '(sudo stop ' + appName + ' || :) && (sudo start ' + appName + ')'
   });
+
+  if (setupNginx) {
+    //configure nginx
+    taskList.copy('Configuring Nginx (App Instance)', {
+      src: path.resolve(TEMPLATES_DIR, 'nginx.conf'),
+      dest: '/etc/nginx/sites-available/' + appName + '.conf',
+      vars: {
+        appPort: env['PORT'] || 80,
+        appRoot: env['ROOT_URL'].replace(/.*?:\/\//g, "")
+      }
+    });
+
+    taskList.executeScript('Configuring Nginx (Enabling Site)', {
+      script: path.resolve(SCRIPT_DIR, 'setup-nginx.sh'),
+      vars: {
+        appName: appName
+      }
+    });
+
+  }
 
   return taskList;
 };

--- a/lib/taskLists/linux.js
+++ b/lib/taskLists/linux.js
@@ -98,6 +98,7 @@ exports.deploy = function(bundlePath, env, deployCheckWaitTime, appName, setupNg
       src: path.resolve(TEMPLATES_DIR, 'nginx.conf'),
       dest: '/etc/nginx/sites-available/' + appName + '.conf',
       vars: {
+        appName: appName,
         appPort: env['PORT'],
         appRoot: env['ROOT_URL'].replace(/.*?:\/\//g, "")
       }
@@ -156,6 +157,7 @@ exports.reconfig = function(env, appName, setupNginx) {
       src: path.resolve(TEMPLATES_DIR, 'nginx.conf'),
       dest: '/etc/nginx/sites-available/' + appName + '.conf',
       vars: {
+        appName: appName,
         appPort: env['PORT'] || 80,
         appRoot: env['ROOT_URL'].replace(/.*?:\/\//g, "")
       }

--- a/lib/taskLists/linux.js
+++ b/lib/taskLists/linux.js
@@ -77,6 +77,23 @@ exports.deploy = function(bundlePath, env, deployCheckWaitTime, appName, setupNg
 
   if (setupNginx) {
     //configure nginx
+
+    taskList.executeScript('Setting up Environment for "'+appName+'"', {
+      script: path.resolve(SCRIPT_DIR, 'setup-env-nginx.sh'),
+      vars: {
+        appName: appName
+      }
+    });
+
+    //Configurations for upstart for different app
+    taskList.copy('Configuring upstart for "'+appName+'"', {
+      src: path.resolve(TEMPLATES_DIR, 'meteor.conf'),
+      dest: '/etc/init/' + appName + '.conf',
+      vars: {
+        appName: appName
+      }
+    });
+
     taskList.copy('Configuring Nginx (App Instance)', {
       src: path.resolve(TEMPLATES_DIR, 'nginx.conf'),
       dest: '/etc/nginx/sites-available/' + appName + '.conf',
@@ -125,22 +142,16 @@ exports.deploy = function(bundlePath, env, deployCheckWaitTime, appName, setupNg
 exports.reconfig = function(env, appName, setupNginx) {
   var taskList = nodemiral.taskList("Updating configurations (linux)");
 
-  taskList.copy('Setting up Environment Variables', {
-    src: path.resolve(TEMPLATES_DIR, 'env.sh'),
-    dest: '/opt/' + appName + '/config/env.sh',
-    vars: {
-      env: env || {},
-      appName: appName
-    }
-  });
-
-  //restarting
-  taskList.execute('Restarting app', {
-    command: '(sudo stop ' + appName + ' || :) && (sudo start ' + appName + ')'
-  });
-
   if (setupNginx) {
     //configure nginx
+
+    taskList.executeScript('Setting up Environment', {
+      script: path.resolve(SCRIPT_DIR, 'setup-env-nginx.sh'),
+      vars: {
+        appName: appName
+      }
+    });
+
     taskList.copy('Configuring Nginx (App Instance)', {
       src: path.resolve(TEMPLATES_DIR, 'nginx.conf'),
       dest: '/etc/nginx/sites-available/' + appName + '.conf',
@@ -158,6 +169,20 @@ exports.reconfig = function(env, appName, setupNginx) {
     });
 
   }
+
+  taskList.copy('Setting up Environment Variables', {
+    src: path.resolve(TEMPLATES_DIR, 'env.sh'),
+    dest: '/opt/' + appName + '/config/env.sh',
+    vars: {
+      env: env || {},
+      appName: appName
+    }
+  });
+
+  //restarting
+  taskList.execute('Restarting app', {
+    command: '(sudo stop ' + appName + ' || :) && (sudo start ' + appName + ')'
+  });
 
   return taskList;
 };

--- a/lib/taskLists/linux.js
+++ b/lib/taskLists/linux.js
@@ -56,8 +56,10 @@ exports.setup = function(config) {
   }
 
   if(config.ssl) {
-    installStud(taskList);
-    configureStud(taskList, config.ssl.pem, config.ssl.backendPort);
+    if (!config.setupNginx) {
+      installStud(taskList);
+      configureStud(taskList, config.ssl.pem, config.ssl.backendPort);
+    }
   }
 
   //Configurations
@@ -72,7 +74,7 @@ exports.setup = function(config) {
   return taskList;
 };
 
-exports.deploy = function(bundlePath, env, deployCheckWaitTime, appName, setupNginx) {
+exports.deploy = function(bundlePath, env, deployCheckWaitTime, appName, setupNginx, ssl) {
   var taskList = nodemiral.taskList("Deploy app '" + appName + "' (linux)");
 
   if (setupNginx) {
@@ -94,8 +96,27 @@ exports.deploy = function(bundlePath, env, deployCheckWaitTime, appName, setupNg
       }
     });
 
+    if (ssl) {
+
+      taskList.copy('Uploading Nginx PEM file', {
+        src: ssl.pem,
+        dest: '/opt/' + appName + '/ssl/nginx.pem'
+      });
+
+      taskList.copy('Uploading Nginx KEY file', {
+        src: ssl.key,
+        dest: '/opt/' + appName + '/ssl/nginx.key'
+      });
+
+    }
+
+    // Different nginx script if it is using SSL
+    var nginxConf = "nginx.conf";
+    if (ssl)
+      nginxConf = "nginx_ssl.conf";
+
     taskList.copy('Configuring Nginx (App Instance)', {
-      src: path.resolve(TEMPLATES_DIR, 'nginx.conf'),
+      src: path.resolve(TEMPLATES_DIR, nginxConf),
       dest: '/etc/nginx/sites-available/' + appName + '.conf',
       vars: {
         appName: appName,

--- a/scripts/linux/install-nginx.sh
+++ b/scripts/linux/install-nginx.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Remove the lock
+set +e
+sudo rm /var/lib/dpkg/lock > /dev/null
+sudo rm /var/cache/apt/archives/lock > /dev/null
+sudo dpkg --configure -a
+set -e
+
+sudo apt-get update -y
+sudo apt-get install nginx -y
+
+# Restart nginx
+sudo service nginx stop || :
+sudo service nginx start

--- a/scripts/linux/setup-env-nginx.sh
+++ b/scripts/linux/setup-env-nginx.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+sudo mkdir -p /opt/<%= appName %>/
+sudo mkdir -p /opt/<%= appName %>/config
+sudo mkdir -p /opt/<%= appName %>/tmp
+
+sudo chown ${USER} /opt/<%= appName %> -R

--- a/scripts/linux/setup-env-nginx.sh
+++ b/scripts/linux/setup-env-nginx.sh
@@ -4,4 +4,6 @@ sudo mkdir -p /opt/<%= appName %>/
 sudo mkdir -p /opt/<%= appName %>/config
 sudo mkdir -p /opt/<%= appName %>/tmp
 
+sudo mkdir -p /opt/<%= appName %>/ssl
+
 sudo chown ${USER} /opt/<%= appName %> -R

--- a/scripts/linux/setup-nginx.sh
+++ b/scripts/linux/setup-nginx.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+## The nginx binary.
+NGINX=$(which nginx)
+[ -x $NGINX ] || exit 0
+
+## The nginx configuration folder
+if [ -d /usr/local/etc/nginx ]; then
+    NGINX_CONF_DIR=/usr/local/etc/nginx
+else
+    NGINX_CONF_DIR=/etc/nginx
+fi
+
+## The paths for both nginx configuration files and the sites
+## configuration files and symbolic link destinations.
+AVAILABLE_SITES_PATH="$NGINX_CONF_DIR/sites-available"
+ENABLED_SITES_PATH="$NGINX_CONF_DIR/sites-enabled"
+AVAILABLE_SITES_DIR="sites-available"
+SCRIPTNAME=${0##*/}
+
+if grep "http://localhost:<%= appPort %>" $AVAILABLE_SITES_PATH/* --exclude=<%= appName %>.conf; then
+    echo "The port <%= appPort %> is already configured on this server"
+    exit 2
+fi
+
+if grep "server_name <%= appName %>" $AVAILABLE_SITES_PATH/* --exclude=<%= appName %>.conf; then
+    echo "The hostname '<%= appName %>' is already configured on this server"
+    exit 2
+fi
+
+SITE_AVAILABLE="$AVAILABLE_SITES_PATH/<%= appName %>.conf"
+SITE_ENABLED="$ENABLED_SITES_PATH/<%= appName %>.conf"
+
+if [ -r $SITE_AVAILABLE ]; then
+  if [ -h $SITE_ENABLED ]; then
+      ## If already enabled say it and exit.
+      echo "$1 is already enabled."
+  else # symlink if not yet enabled
+      ln -s $SITE_AVAILABLE $SITE_ENABLED
+  fi
+  ## Test for a well formed configuration.
+  echo "Testing nginx configuration..."
+  $NGINX -t && STATUS=0
+  if [ $STATUS ]; then
+      echo -n "Site $1 has been enabled. "
+  else
+      exit 2
+  fi
+else
+  echo "Site configuration file $1 not found."
+  exit 3
+fi
+
+echo "Testing nginx configuration..."
+$NGINX -t && STATUS=0
+if [ $STATUS ]; then
+    echo -n "Site $1 has been enabled. "
+else
+    exit 2
+fi
+
+sudo service nginx reload

--- a/templates/linux/index.html
+++ b/templates/linux/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
+<title>Welcome to nginx & meteor-up!</title>
+<style>
+    body {
+        width: 35em;
+        margin: 0 auto;
+        font-family: Tahoma, Verdana, Arial, sans-serif;
+    }
+</style>
+</head>
+<body>
+<h1>Welcome to nginx &amp; meteor-up!</h1>
+
+<p>If you see this page, meteor-up has has installed the nginx web server successfully.</p>
+
+<p>Visit your applicaiton ROOT_URL to see your app running.</p>
+
+<p>For online documentation and support please refer to
+<a href="http://nginx.org/">nginx.org</a>.<br>
+Commercial support is available at
+<a href="http://nginx.com/">nginx.com</a>.</p>
+Deploy Meteor apps with ease using
+<a href="https://github.com/aaronthorp/meteor-up">meteor-up</a>.</p>
+
+<p><em>Thank you for using nginx &amp; meteor-up.</em></p>
+
+<p>Nginx/meteor-up feature created by: <a href="http://www.aaronthorp.com">Aaron Thorp</a></p>

--- a/templates/linux/nginx.conf
+++ b/templates/linux/nginx.conf
@@ -15,12 +15,12 @@ server {
     }
 
     ## serve static files by nginx instead of Meteor (the public/ folder) - Thanks @yauh :)
-    location ~ \.(jpg|jpeg|png|gif|mp3|ico|pdf) {
-      root /opt/<%= appName %>/app/programs/web.browser/app; # this should point at the content from the public folder
-      access_log off;
-      expires 30d;
-      add_header Pragma public;
-      add_header Cache-Control "public";
-    }
+    #location ~ \.(jpg|jpeg|png|gif|mp3|ico|pdf) {
+    #  root /opt/<%= appName %>/app/programs/web.browser/app; # this should point at the content from the public folder
+    #  access_log off;
+    #  expires 30d;
+    #  add_header Pragma public;
+    #  add_header Cache-Control "public";
+    #}
 
 }

--- a/templates/linux/nginx.conf
+++ b/templates/linux/nginx.conf
@@ -12,4 +12,13 @@ server {
         proxy_cache_bypass $http_upgrade;
     }
 
+    ## serve static files by nginx instead of Meteor (the public/ folder)
+    location ~ \.(jpg|jpeg|png|gif|mp3|ico|pdf) {
+      root /opt/<%= appName %>/app/programs/web.browser/app; # this should point at the content from the public folder
+      access_log off;
+      expires 30d;
+      add_header Pragma public;
+      add_header Cache-Control "public";
+    }
+
 }

--- a/templates/linux/nginx.conf
+++ b/templates/linux/nginx.conf
@@ -12,7 +12,7 @@ server {
         proxy_cache_bypass $http_upgrade;
     }
 
-    ## serve static files by nginx instead of Meteor (the public/ folder)
+    ## serve static files by nginx instead of Meteor (the public/ folder) - Thanks @yauh :)
     location ~ \.(jpg|jpeg|png|gif|mp3|ico|pdf) {
       root /opt/<%= appName %>/app/programs/web.browser/app; # this should point at the content from the public folder
       access_log off;

--- a/templates/linux/nginx.conf
+++ b/templates/linux/nginx.conf
@@ -3,6 +3,8 @@ server {
 
     server_name <%= appRoot %>;
 
+    client_max_body_size 20M;
+
     location / {
         proxy_pass http://localhost:<%= appPort %>;
         proxy_http_version 1.1;

--- a/templates/linux/nginx.conf
+++ b/templates/linux/nginx.conf
@@ -1,0 +1,15 @@
+server {
+    listen 80;
+
+    server_name <%= appRoot %>;
+
+    location / {
+        proxy_pass http://localhost:<%= appPort %>;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+}

--- a/templates/linux/nginx_ssl.conf
+++ b/templates/linux/nginx_ssl.conf
@@ -1,11 +1,11 @@
 server {
   listen 80;
-  listen 443 default ssl;
+  listen 443 ssl;
 
   server_name <%= appRoot %>;
 
   client_max_body_size 20M;
-  
+
   if ($scheme = http) {
     rewrite ^ https://$server_name$request_uri permanent;
   }

--- a/templates/linux/nginx_ssl.conf
+++ b/templates/linux/nginx_ssl.conf
@@ -1,0 +1,32 @@
+server {
+  listen 80;
+  listen 443 default ssl;
+
+  server_name <%= appRoot %>;
+
+  if ($scheme = http) {
+    rewrite ^ https://$server_name$request_uri permanent;
+  }
+
+  ssl_certificate      /opt/<%= appName %>/ssl/nginx.pem;
+  ssl_certificate_key  /opt/<%= appName %>/ssl/nginx.key;
+
+  location / {
+      proxy_pass http://localhost:<%= appPort %>;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection 'upgrade';
+      proxy_set_header Host $host;
+      proxy_cache_bypass $http_upgrade;
+  }
+
+  ## serve static files by nginx instead of Meteor (the public/ folder) - Thanks @yauh :)
+  location ~ \.(jpg|jpeg|png|gif|mp3|ico|pdf) {
+    root /opt/<%= appName %>/app/programs/web.browser/app; # this should point at the content from the public folder
+    access_log off;
+    expires 30d;
+    add_header Pragma public;
+    add_header Cache-Control "public";
+  }
+
+}

--- a/templates/linux/nginx_ssl.conf
+++ b/templates/linux/nginx_ssl.conf
@@ -4,6 +4,8 @@ server {
 
   server_name <%= appRoot %>;
 
+  client_max_body_size 20M;
+  
   if ($scheme = http) {
     rewrite ^ https://$server_name$request_uri permanent;
   }


### PR DESCRIPTION
For your consideration @arunoda, I am now using this mod for my own servers and deployment but could be quite popular for other Meteor users. 

My requirements were to be able to host multiple apps on a single server with `mup deploy` feature only to deploy them, came up with the following changes to get that to work.

This allows you to do the following:
- Host multiple applications on a single server using unique specified ports in `env` variable
- Define a unique port and `ROOT_URL` for each instance and Nginx will proxy forward accordingly
- Prevents multiple deployments of the same `PORT` on a single server if the `appName` is different
- add `setupNginx:true` to `mup.json` and specify a `PORT` and `ROOT_URL` in the environment variables
- Provide a unique `appName` for each app. This will install it into its own folder and own upstart on the server.

Things yet to implement and future ideas:
- SSL support for Nginx
- `mup remove` command to remove an app from a nginx configured server
- global `mup_server.json` file to store named server instances to then deploy apps to by specifying server name only

Thoughts?
