### PR TITLE
optionally specify mup config file in cli args for different deploy targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ You can use an array to deploy the same configuration to multiple servers at onc
 
 To deploy different configurations (e.g. staging, production, etc.), you can use separate Meteor Up configuration files for each target. Specify the target configuration file following a command, for example: `meteor deploy staging.json`.
 
-If you are deploying multiple configurations to the same server, make sure each has a unique `appName` field and `PORT` environment variable.
+If you are deploying multiple configurations to the same server, make sure each has a unique `appName` field and `PORT` environment variable.  Meteor Up only does the deployment; if you need to configure subdomains, you need to manually setup a reverse proxy yourself.
 
 #### Custom Meteor Binary
 
@@ -244,18 +244,6 @@ It is possible to provide server specific environment variables. Add the `env` o
 ~~~
 
 By default, Meteor UP adds `CLUSTER_ENDPOINT_URL` to make [cluster](https://github.com/meteorhacks/cluster) deployment simple. But you can override it by defining it yourself.
-
-### Multiple Deployments
-
-Meteor Up supports multiple deployments to a single server. Meteor Up only does the deployment; if you need to configure subdomains, you need to manually setup a reverse proxy yourself.
-
-Let's assume, we need to deploy production and staging versions of the app to the same server. The production app runs on port 80 and the staging app runs on port 8000.
-
-We need to have two separate Meteor Up projects. For that, create two directories and initialize Meteor Up and add the necessary configurations.
-
-In the staging `mup.json`, add a field called `appName` with the value `staging`. You can add any name you prefer instead of `staging`. Since we are running our staging app on port 8000, add an environment variable called `PORT` with the value 8000.
-
-Now setup both projects and deploy as you need.
 
 ### SSL Support
 

--- a/README.md
+++ b/README.md
@@ -181,9 +181,11 @@ Meteor Up checks if the deployment is successful or not just after the deploymen
 
 #### Multiple Deployment Targets
 
-You can use an array to deploy to multiple servers at once.
+You can use an array to deploy the same configuration to multiple servers at once.
 
-To deploy to *different* environments (e.g. staging, production, etc.), use separate Meteor Up configurations in separate directories, with each directory containing separate `mup.json` and `settings.json` files, and the `mup.json` files' `app` field pointing back to your app's local directory.
+To deploy different configurations (e.g. staging, production, etc.), you can use separate Meteor Up configuration files for each target. Specify the target configuration file following a command, for example: `meteor deploy staging.json`.
+
+If you are deploying multiple configurations to the same server, make sure each has a unique `appName` field and `PORT` environment variable.
 
 #### Custom Meteor Binary
 

--- a/bin/mup
+++ b/bin/mup
@@ -16,8 +16,13 @@ if(action == 'init') {
   ActionsRegistry.init();
 } else {
   var cwd = path.resolve('.');
+
   //read config and validate it
-  var config = Config.read();
+  var mupJsonFile = process.argv[3]
+  if(typeof mupJsonFile === "undefined") {
+    mupJsonFile = "mup.json";
+  }
+  var config = Config.read(mupJsonFile);
 
   if(config._passwordExists) {
     //check for sshpass

--- a/lib/config.js
+++ b/lib/config.js
@@ -6,8 +6,8 @@ var format = require('util').format;
 
 require('colors');
 
-exports.read = function() {
-  var mupJsonPath = path.resolve('mup.json');
+exports.read = function(mupJsonFile) {
+  var mupJsonPath = path.resolve(mupJsonFile);
   if(fs.existsSync(mupJsonPath)) {
     var mupJson = cjson.load(mupJsonPath);
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -13,16 +13,16 @@ exports.checkSshPassExists = function(callback) {
 exports.printHelp = function() {
   console.error('\nValid Actions');
   console.error('-------------');
-  console.error('init          - Initialize a Meteor Up project');
-  console.error('setup         - Setup the server');
+  console.error('init                          - Initialize a Meteor Up project');
+  console.error('setup [<config-file>]         - Setup the server');
   console.error('');
-  console.error('deploy        - Deploy app to server');
-  console.error('reconfig      - Reconfigure the server and restart');
+  console.error('deploy [<config-file>]        - Deploy app to server');
+  console.error('reconfig [<config-file>]      - Reconfigure the server and restart');
   console.error('');
-  console.error('logs [-f -n]  - Access logs');
+  console.error('logs [-f -n] [<config-file>]  - Access logs');
   console.error('');
-  console.error('start         - Start your app instances');
-  console.error('stop          - Stop your app instances');
-  console.error('restart       - Restart your app instances');
+  console.error('start [<config-file>]         - Start your app instances');
+  console.error('stop [<config-file>]          - Stop your app instances');
+  console.error('restart [<config-file>]       - Restart your app instances');
 
 };


### PR DESCRIPTION
Instead of using separate directories, so it works more like `meteor deploy [site]`, which is the expected behavior for a few people (including myself). Fixes #4 #14
