### PR TITLE
Quote variables when substituting them into the env script.

### DIFF
--- a/templates/linux/env.sh
+++ b/templates/linux/env.sh
@@ -5,5 +5,5 @@ export ROOT_URL=http://localhost
 
 #it is possible to override above env-vars from the user-provided values
 <% for(var key in env) { %>
-  export <%- key %>=<%- ("" + env[key]).replace(/./ig, '\\$&') %>
+  export <%- key %>=<%- ('"' + env[key] + '"').replace(/./ig, '\\$&') %>
 <% } %>

--- a/templates/sunos/env.sh
+++ b/templates/sunos/env.sh
@@ -5,5 +5,5 @@ export ROOT_URL=http://localhost
 
 #it is possible to override above env-vars from the user-provided values
 <% for(var key in env) { %>
-  export <%- key %>=<%- ("" + env[key]).replace(/./ig, '\\$&') %>
+  export <%- key %>=<%- ('"' + env[key] + '"').replace(/./ig, '\\$&') %>
 <% } %>


### PR DESCRIPTION
Fix the case where you need to escape quotes into the config json, by always putting environment variables in quotes in the env.sh script.
