### PR TITLE
Exit if docker is installed before apt-get.

### DIFF
--- a/scripts/linux/install-docker.sh
+++ b/scripts/linux/install-docker.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+set +e
+haveDocker=$(docker version | grep "version")
+set -e
+
+if [ "$haveDocker" ]; then
+  exit 0;
+fi
+
 # Remove the lock
 set +e
 sudo rm /var/lib/dpkg/lock > /dev/null
@@ -11,10 +19,4 @@ set -e
 sudo apt-get update
 
 # Install docker
-set +e
-haveDocker=$(docker version | grep "version")
-set -e
-
-if [ ! "$haveDocker" ]; then
-  wget -qO- https://get.docker.com/ | sudo sh
-fi
+wget -qO- https://get.docker.com/ | sudo sh


### PR DESCRIPTION
Allows meteor up to work in non debian distributions like fedora atomic or coreos when docker is already installed.
