### PR TITLE
Do nothing if docker is already installed

### DIFF
--- a/scripts/linux/install-docker.sh
+++ b/scripts/linux/install-docker.sh
@@ -1,20 +1,22 @@
 #!/bin/bash
 
-# Remove the lock
-set +e
-sudo rm /var/lib/dpkg/lock > /dev/null
-sudo rm /var/cache/apt/archives/lock > /dev/null
-sudo dpkg --configure -a
-set -e
-
-# Required to update system
-sudo apt-get update
-
-# Install docker
+# Is docker already installed?
 set +e
 haveDocker=$(docker version | grep "version")
 set -e
 
 if [ ! "$haveDocker" ]; then
+
+  # Remove the lock
+  set +e
+  sudo rm /var/lib/dpkg/lock > /dev/null
+  sudo rm /var/cache/apt/archives/lock > /dev/null
+  sudo dpkg --configure -a
+  set -e
+
+  # Required to update system
+  sudo apt-get update
+
+  # Install docker
   wget -qO- https://get.docker.com/ | sudo sh
 fi


### PR DESCRIPTION
I had an issue trying to run mupx against a core os machine. Core os doesn't include apt, dpkg, etc, so the `apt-get update` was failing. However, docker is already installed and operational.

I modified the `install-docker.sh` script slightly to wrap all actions in the `if` block, that way on machines which already have docker installed, the script will not do anything.
