### PR TITLE
start forever in upstart with all root enviroment variables

### DIFF
--- a/templates/linux/meteor.conf
+++ b/templates/linux/meteor.conf
@@ -23,7 +23,7 @@ script
     
     if [ -z $UPSTART_UID ]; then
       ##start the app using userdown
-      forever -c userdown --minUptime 2000 --spinSleepTime 1000 app/main.js
+      exec su root -c 'forever -c userdown --minUptime 2000 --spinSleepTime 1000 app/main.js'
     else
       ##start the app as UPSTART_UID
       exec su -s /bin/sh -c 'exec "$0" "$@"' $UPSTART_UID -- forever --minUptime 2000 --spinSleepTime 1000 app/main.js


### PR DESCRIPTION
Starting my meteor application via mup's upstart was causing phantomjs (spiderable) to behave incorrectly. The following error was displayed on every page when pages where requested using the escaped fragment (?_escaped_fragment_=)

```
Error: Plural Function not found for locale: C http://my-meteor-app/2f6b02664bc6facd232b9bf0814a02be6b0d0d1d.js:159 in e http://my-meteor-app/2f6b02664bc6facd232b9bf0814a02be6b0d0d1d.js:159 http://my-meteor-app/2f6b02664bc6facd232b9bf0814a02be6b0d0d1d.js:710 http://my-meteor-app/2f6b02664bc6facd232b9bf0814a02be6b0d0d1d.js:950 http://my-meteor-app/2f6b02664bc6facd232b9bf0814a02be6b0d0d1d.js:60 http://my-meteor-app/2f6b02664bc6facd232b9bf0814a02be6b0d0d1d.js:60 http://my-meteor-app/2f6b02664bc6facd232b9bf0814a02be6b0d0d1d.js:60 http://my-meteor-app/2f6b02664bc6facd232b9bf0814a02be6b0d0d1d.js:60 http://my-meteor-app/2f6b02664bc6facd232b9bf0814a02be6b0d0d1d.js:59 in n http://my-meteor-app/2f6b02664bc6facd232b9bf0814a02be6b0d0d1d.js:18 http://my-meteor-app/2f6b02664bc6facd232b9bf0814a02be6b0d0d1d.js:59 http://my-meteor-app/2f6b02664bc6facd232b9bf0814a02be6b0d0d1d.js:59 http://my-meteor-app/2f6b02664bc6facd232b9bf0814a02be6b0d0d1d.js:59 http://my-meteor-app/2f6b02664bc6facd232b9bf0814a02be6b0d0d1d.js:59 http://my-meteor-app/2f6b02664bc6facd232b9bf0814a02be6b0d0d1d.js:59 http://my-meteor-app/2f6b02664bc6facd232b9bf0814a02be6b0d0d1d.js:59 http://my-meteor-app/2f6b02664bc6facd232b9bf0814a02be6b0d0d1d.js:59 http://my-meteor-app/2f6b02664bc6facd232b9bf0814a02be6b0d0d1d.js:59 http://my-meteor-app/2f6b02664bc6facd232b9bf0814a02be6b0d0d1d.js:18 http://my-meteor-app/2f6b02664bc6facd232b9bf0814a02be6b0d0d1d.js:59 http://my-meteor-app/2f6b02664bc6facd232b9bf0814a02be6b0d0d1d.js:59 http://my-meteor-app/2f6b02664bc6facd232b9bf0814a02be6b0d0d1d.js:143 http://my-meteor-app/2f6b02664bc6facd232b9bf0814a02be6b0d0d1d.js:155 http://my-meteor-app/2f6b02664bc6facd232b9bf0814a02be6b0d0d1d.js:155 in t
```

Please note that phantomjs was not throwing errors, but it was interfering with messageformat, which is the package we are using for localization.
After digging in this problem for a while, I have discovered that starting the application without upstart, phantomjs was not interfering anymore with messageformat and everything was working correctly as expected.
Basically, accessing the server via ssh and lauching:

```
export USERDOWN_UID=meteoruser USERDOWN_GID=meteoruser
. /opt/webapp/config/env.sh
forever -c userdown --minUptime 2000 --spinSleepTime 1000 app/main.js
```

the meteor application was working correctly and the phantomjs was rendering correctly all pages accessed by the escaped fragment.
It looks like spiderable/phantomjs is depending on some environment variables that are not set under upstart. 
Appending  `exec su root -c` before running upstart, it makes sure that all environment variables are set before starting the application

i'm using phantomjs 1.9.8 and my meteor packages files is:

```
# Meteor packages used by this project, one per line.
#
# 'meteor add' and 'meteor remove' will edit this file for you,
# but you can also edit it by hand.
standard-app-packages
jquery
alanning:roles
accounts-base
accounts-password
accounts-twitter
gadicohen:headers
jeeeyul:moment-with-langs
accounts-facebook
accounts-google
sacha:spin
dandv:jquery-rateit
email
gfk:notifications
less
raix:handlebar-helpers
underscore
meteorhacks:npm
npm-container
rajit:bootstrap3-datepicker
reactive-dict
iron:router
veg-accounts-ui
bootstrap-3
bootstrap3-confirmation
gadicohen:phantomjs
gadicohen:messageformat
meteorhacks:inject-initial
altapp:urlify2-minifiable
multiply:iron-router-progress
meteorhacks:aggregate
meteorhacks:ssr
tsega:bootstrap3-datetimepicker@3.1.3_3
reactive-var
meteorhacks:subs-manager
jazeee:spiderable-longer-timeout
yasinuslu:blaze-meta
sergeyt:livequery
```

Please let me know if it makes sense to start forever in this way.
