### PR TITLE
use single equals sign for POSIX-compatible string comparison

### DIFF
--- a/templates/linux/deploy.sh
+++ b/templates/linux/deploy.sh
@@ -27,7 +27,7 @@ gyp_rebuild_inside_node_modules () {
 
     check_for_binary_modules
 
-    if [ $isBinaryModule == "yes" ]; then
+    if [ $isBinaryModule = "yes" ]; then
       echo " > $npmModule: npm install due to binary npm modules"
       rm -rf node_modules
       if [ -f binding.gyp ]; then


### PR DESCRIPTION
Small fix for if statement in `gyp_rebuild_inside_node_modules()`
