### PR TITLE
Allows overriding author on /templates/meteor.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ This will create two files in your Meteor Up project directory:
 
   // Application name (no spaces).
   "appName": "meteor",
+  "appAuthor": "Arunoda Susiripala, <arunoda.susiripala@gmail.com>",
 
   // Location of app (local directory). This can reference '~' as the users home directory.
   // i.e., "app": "~/Meteor/my-app",

--- a/example/mup.json
+++ b/example/mup.json
@@ -28,6 +28,7 @@
 
   // Application name (No spaces)
   "appName": "meteor",
+  "appAuthor": "Arunoda Susiripala, <arunoda.susiripala@gmail.com>",
 
   // Location of app (local directory)
   "app": "/path/to/the/app",

--- a/example/mup.json
+++ b/example/mup.json
@@ -28,6 +28,8 @@
 
   // Application name (No spaces)
   "appName": "meteor",
+
+  // Application author
   "appAuthor": "Arunoda Susiripala, <arunoda.susiripala@gmail.com>",
 
   // Location of app (local directory)

--- a/lib/config.js
+++ b/lib/config.js
@@ -24,6 +24,9 @@ exports.read = function() {
     if(typeof mupJson.appName === "undefined") {
       mupJson.appName = "meteor";
     }
+    if(typeof mupJson.appName === "undefined") {
+      mupJson.appName = "Arunoda Susiripala, <arunoda.susiripala@gmail.com>";
+    }
     if(typeof mupJson.enableUploadProgressBar === "undefined") {
       mupJson.enableUploadProgressBar = true;
     }

--- a/lib/taskLists/linux.js
+++ b/lib/taskLists/linux.js
@@ -53,7 +53,8 @@ exports.setup = function(config) {
     src: path.resolve(TEMPLATES_DIR, 'meteor.conf'),
     dest: '/etc/init/' + config.appName + '.conf',
     vars: {
-      appName: config.appName
+      appName: config.appName,
+      appAuthor: config.appAuthor
     }
   });
 

--- a/templates/linux/meteor.conf
+++ b/templates/linux/meteor.conf
@@ -1,6 +1,6 @@
 #!upstart
 description "Meteor Up - <%= appName %>"
-author      "Arunoda Susiripala, <arunoda.susiripala@gmail.com>"
+author      "<%= appAuthor %>"
 
 start on runlevel [2345]
 stop on runlevel [06]


### PR DESCRIPTION
It confused me to have your own name show up on the generated upstart file, instead of our own company's (no offense hope :stuck_out_tongue: )

This allows overriding that string in `mup.conf`, while still keeping the original value as a default
