### PR TITLE
Updated build location path to use OS tmp directory

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -10,6 +10,7 @@ var extend = require('util')._extend;
 var _ = require('underscore');
 var async = require('async');
 var buildApp = require('./build.js');
+var os = require('os');
 require('colors');
 
 module.exports = Actions;
@@ -79,7 +80,7 @@ Actions.prototype._executePararell = function(actionName, args) {
   var self = this;
   var sessionInfoList = _.values(self.sessionsMap);
   async.map(
-    sessionInfoList, 
+    sessionInfoList,
     function(sessionsInfo, callback) {
       var taskList = sessionsInfo.taskListsBuilder[actionName]
         .apply(sessionsInfo.taskListsBuilder, args);
@@ -100,7 +101,7 @@ Actions.prototype.deploy = function() {
   var self = this;
   self._showKadiraLink();
 
-  var buildLocation = path.resolve('/tmp', uuid.v4());
+  var buildLocation = path.resolve(os.tmpdir(), uuid.v4());
   var bundlePath = path.resolve(buildLocation, 'bundle.tar.gz');
 
   // spawn inherits env vars from process.env


### PR DESCRIPTION
Build location now use the OS defined temporary directory instead of hard coded "/tmp".
