### PR TITLE
added debug flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.log
+.idea

--- a/README.md
+++ b/README.md
@@ -129,7 +129,10 @@ This will create two files in your Meteor Up project directory:
 
   // Meteor Up checks if the app comes online just after the deployment.
   // Before mup checks that, it will wait for the number of seconds configured below.
-  "deployCheckWaitTime": 15
+  "deployCheckWaitTime": 15,
+
+  // Debug, launches Meteor with --debug flag, allows easier debugging in console
+  "debug": true
 }
 ```
 

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -114,9 +114,10 @@ Actions.prototype.deploy = function() {
   var enableUploadProgressBar = this.config.enableUploadProgressBar;
   var meteorBinary = this.config.meteorBinary;
   var debug = this.config.debug || false;
+  var serverLocation = this.config.server || 'http://localhost:3000';
 
   console.log('Building Started: ' + this.config.app);
-  buildApp(appPath, meteorBinary, debug, buildLocation, function(err) {
+  buildApp(appPath, meteorBinary, debug, buildLocation, serverLocation, function(err) {
     if(err) {
       process.exit(1);
     } else {

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -113,9 +113,10 @@ Actions.prototype.deploy = function() {
   var appPath = this.config.app;
   var enableUploadProgressBar = this.config.enableUploadProgressBar;
   var meteorBinary = this.config.meteorBinary;
+  var debug = this.config.debug || false;
 
   console.log('Building Started: ' + this.config.app);
-  buildApp(appPath, meteorBinary, buildLocation, function(err) {
+  buildApp(appPath, meteorBinary, debug, buildLocation, function(err) {
     if(err) {
       process.exit(1);
     } else {

--- a/lib/build.js
+++ b/lib/build.js
@@ -34,8 +34,6 @@ function buildMeteorApp(appPath, meteorBinary, debug, buildLocation, serverLocat
     args = ["/c", "meteor"].concat(args);
   }
 
-  console.log( 'buildMeteorApp', args );
-
   var options = {cwd: appPath};
   var meteor = spawn(executable, args, options);
   var stdout = "";

--- a/lib/build.js
+++ b/lib/build.js
@@ -4,8 +4,8 @@ var fs = require('fs');
 var pathResolve = require('path').resolve;
 var _ = require('underscore');
 
-function buildApp(appPath, meteorBinary, debug, buildLocation, callback) {
-  buildMeteorApp(appPath, meteorBinary, debug, buildLocation, function(code) {
+function buildApp(appPath, meteorBinary, debug, buildLocation, serverLocation, callback) {
+  buildMeteorApp(appPath, meteorBinary, debug, buildLocation, serverLocation, function(code) {
     if(code == 0) {
       archiveIt(buildLocation, callback);
     } else {
@@ -15,11 +15,11 @@ function buildApp(appPath, meteorBinary, debug, buildLocation, callback) {
   });
 }
 
-function buildMeteorApp(appPath, meteorBinary, debug, buildLocation, callback) {
+function buildMeteorApp(appPath, meteorBinary, debug, buildLocation, serverLocation, callback) {
   var executable = meteorBinary;
   var args = [
     "build", "--directory", buildLocation,
-    "--server", "http://localhost:3000"
+    "--server", serverLocation
   ];
 
   if (debug){
@@ -33,6 +33,8 @@ function buildMeteorApp(appPath, meteorBinary, debug, buildLocation, callback) {
     executable = process.env.comspec || "cmd.exe";
     args = ["/c", "meteor"].concat(args);
   }
+
+  console.log( 'buildMeteorApp', args );
 
   var options = {cwd: appPath};
   var meteor = spawn(executable, args, options);

--- a/lib/build.js
+++ b/lib/build.js
@@ -4,10 +4,10 @@ var fs = require('fs');
 var pathResolve = require('path').resolve;
 var _ = require('underscore');
 
-function buildApp(appPath, meteorBinary, buildLocaltion, callback) {
-  buildMeteorApp(appPath, meteorBinary, buildLocaltion, function(code) {
+function buildApp(appPath, meteorBinary, debug, buildLocation, callback) {
+  buildMeteorApp(appPath, meteorBinary, debug, buildLocation, function(code) {
     if(code == 0) {
-      archiveIt(buildLocaltion, callback);
+      archiveIt(buildLocation, callback);
     } else {
       console.log("\n=> Build Error. Check the logs printed above.");
       callback(new Error("build-error"));
@@ -15,12 +15,16 @@ function buildApp(appPath, meteorBinary, buildLocaltion, callback) {
   });
 }
 
-function buildMeteorApp(appPath, meteorBinary, buildLocaltion, callback) {
+function buildMeteorApp(appPath, meteorBinary, debug, buildLocation, callback) {
   var executable = meteorBinary;
   var args = [
-    "build", "--directory", buildLocaltion, 
+    "build", "--directory", buildLocation,
     "--server", "http://localhost:3000"
   ];
+
+  if (debug){
+    args.push("--debug");
+  }
   
   var isWin = /^win/.test(process.platform);
   if(isWin) {


### PR DESCRIPTION
Sometimes it's nice to deploy a development server and be able to use the debugger client side, previously I set "meteorBinary": "/usr/local/bin/meteor --debug" however as of Meteor 1.2 this doesn't seem to work anymore, so I had to add this.
