### PR TITLE
added wkhtmltopdf as an optional server install

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ You can use install and use Meteor Up from Linux, Mac and Windows.
 * Revert to the previous version, if the deployment failed
 * Secured MongoDB Installation (Optional)
 * Pre-Installed PhantomJS (Optional)
+* Pre-Installed wkhtmltopdf (Optional)
 
 ### Installation
 
@@ -104,6 +105,9 @@ This will create two files in your Meteor Up project directory:
 
   // Install PhantomJS on the server
   "setupPhantom": true,
+
+  // Install wkhtmltopdf on the server
+  "setupWkhtmltopdf": true,
 
   // Show a progress bar during the upload of the bundle to the server.
   // Might cause an error in some rare cases if set to true, for instance in Shippable CI
@@ -187,7 +191,7 @@ And you also need to add NOPASSWD to the sudoers file:
     %sudo  ALL=(ALL) ALL
 
     # by this line
-    %sudo ALL=(ALL) NOPASSWD:ALL  
+    %sudo ALL=(ALL) NOPASSWD:ALL
 
 When this process is not working you might encounter the following error:
 

--- a/example/mup.json
+++ b/example/mup.json
@@ -21,8 +21,9 @@
 
   // Install PhantomJS in the server
   "setupPhantom": true,
+  "setupWkhtmltopdf": true,
 
-  // Show a progress bar during the upload of the bundle to the server. 
+  // Show a progress bar during the upload of the bundle to the server.
   // Might cause an error in some rare cases if set to true, for instance in Shippable CI
   "enableUploadProgressBar": true,
 

--- a/lib/taskLists/linux.js
+++ b/lib/taskLists/linux.js
@@ -25,6 +25,12 @@ exports.setup = function(config) {
     });
   }
 
+  if(config.setupWkhtmltopdf) {
+    taskList.executeScript('Installing wkhtmltopdf', {
+      script: path.resolve(SCRIPT_DIR, 'install-wkhtmltopdf.sh')
+    });
+  }
+
   taskList.executeScript('Setting up Environment', {
     script: path.resolve(SCRIPT_DIR, 'setup-env.sh'),
     vars: {

--- a/scripts/linux/install-wkhtmltopdf.sh
+++ b/scripts/linux/install-wkhtmltopdf.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Remove the lock
+set +e
+sudo rm /var/lib/dpkg/lock > /dev/null
+sudo rm /var/cache/apt/archives/lock > /dev/null
+set -e
+
+# Install wkhtmltopdf
+apt-get update
+sudo apt-get -y install libjpeg8-dev libxrender1 fontconfig > /dev/null
+
+WKHTMLTOPDF_VERSION=0.12.2.1
+
+cd /usr/local/share/
+mkdir tmp
+cd tmp
+sudo wget http://download.gna.org/wkhtmltopdf/0.12/0.12.2.1/wkhtmltox-0.12.2.1_linux-trusty-amd64.deb > /dev/null
+ar -vx wkhtmltox-0.12.2.1_linux-trusty-amd64.deb
+tar xf data.tar.xz
+cp usr/local/bin/wkhtmltopdf ../wkhtmltopdf
+sudo ln -s -f /usr/local/share/wkhtmltopdf /usr/local/bin/wkhtmltopdf
+sudo ln -s -f /usr/local/share/wkhtmltopdf /usr/bin/wkhtmltopdf
+
+# Clean up
+rm -rf /usr/local/share/tmp


### PR DESCRIPTION
Similar to PhantomJS setup option, this PR will add the optional flag to install the http://wkhtmltopdf.org/ library on the server on setup.
