### PR TITLE
Added Mongo Dump/Restore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.log
+.idea

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ This will bundle the Meteor project and deploy it to the server. Bundling proces
 You may add any of the mongo options, but --out will be used as a local target directory for the dump to be transferred to ounce completed, and not the final filename. (The default is /opt/backups on both machines).
 Use --dockerId to manually override, otherwise automatic Mongo Docker container detection. The -v flag adds verbose console logging. Also noted adding --oplog is important, but will fail if not enabled on the 'mongod' docker container.
 The --in can be omitted if last argument is the path of the restoration directory (same as mongodump creates). All other arguments are passed through.
-When Mongo is restoring the action to Drop/Delete is turned on in the mup.json settings file via "restoreDrops", or the environment variable RESTORE_DROPS. Also noCleanUp and env NO_CLEANUP (--cli no argument) will not purge or clean-up the remote /opt/backups folder.
+When Mongo is restoring the action to Drop/Delete is turned on in the mup.json settings file via omission of "noDrop", otherwise add it or set the environment variable NO_DROP. Also noCleanUp and env NO_CLEANUP (--cli no argument) will not purge or clean-up the remote /opt/backups folder.
 It's useful to understand that the Mongo container is created in "setup" and not when deploying the app. It links the docker container to the docker host's /var/lib/mongodb folder, and this doesn't get overwritten without using --stomp.
 Sometimes this can become locked. You're supposed to do a repair but can force a --lockRemoval without too much concern. For an added convenience there is a 'mongounlock' command.
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ When building the meteor app, we can invoke few options. So, you can mention the
   // build with the debug mode on
   "debug": true,
   // mobile setting for cordova apps
+  // if you do not add mobileSettings .meteor/platforms gets over written with 'server' and 'browser' only during deployment to avoid build errors.
   "mobileSettings": {
     "public": {
       "meteor-up": "rocks"

--- a/README.md
+++ b/README.md
@@ -137,6 +137,19 @@ This will bundle the Meteor project and deploy it to the server. Bundling proces
 * `mupx restart` - restart the app
 * `mupx logs [-f --tail=50]` - get logs
 
+### Mongo Local Backup & Restore
+
+* `mupx mongoDump | md [--out localDir --dockerId ???????????? ]` - perform mongo database dump on an automatic mongo docker detected instance, or you may choose to set the dockerId explicitly.
+* `mupx mongoRestore | mr [--in localDir --dockerId ???????????? ]` - use a local folder to restore the database on an automatic mongo docker detected instance, or you may choose to set the dockerId explicitly.
+* `mupx mongoUnlock | mu - Sometime mongo won't start without removing a lock file. In production you should follow up with a Repair at that point.
+* `mupx mongoUnlockRemote | murt - If it's caught in a startup loop you can't do it Remotely. It can be used as a pre-shutdown procedure so it doesn't jam on restart. {It's just a tool that can come in handy.}[Proper Repair is recommended.]
+You may add any of the mongo options, but --out will be used as a local target directory for the dump to be transferred to ounce completed, and not the final filename. (The default is /opt/backups on both machines).
+Use --dockerId to manually override, otherwise automatic Mongo Docker container detection. The -v flag adds verbose console logging. Also noted adding --oplog is important, but will fail if not enabled on the 'mongod' docker container.
+The --in can be omitted if last argument is the path of the restoration directory (same as mongodump creates). All other arguments are passed through.
+When Mongo is restoring the action to Drop/Delete is turned on in the mup.json settings file via "restoreDrops", or the environment variable RESTORE_DROPS. Also noCleanUp and env NO_CLEANUP (--cli no argument) will not purge or clean-up the remote /opt/backups folder.
+It's useful to understand that the Mongo container is created in "setup" and not when deploying the app. It links the docker container to the docker host's /var/lib/mongodb folder, and this doesn't get overwritten without using --stomp.
+Sometimes this can become locked. You're supposed to do a repair but can force a --lockRemoval without too much concern. For an added convenience there is a 'mongounlock' command.
+
 ### Build Options
 
 When building the meteor app, we can invoke few options. So, you can mention them in `mup.json` like this:
@@ -214,7 +227,7 @@ Meteor Up uses Docker to run and manage your app. It uses [MeteorD](https://gith
 * we've a demonized docker container running the above bundle.
 * docker container is started with `--restart=always` flag and it'll re-spawn the container if dies.
 * logs are maintained via Docker.
-* If you decided to use MongoDB, it'll be also running as a Docker conatiner. It's bound to the local interface and port 27017 (you cannot access from the outside)
+* If you decided to use MongoDB, it'll be also running as a Docker container. It's bound to the local interface and port 27017 (you cannot access from the outside)
 * the database is named `<appName>`
 
 For more information see [`lib/taskLists.js`](https://github.com/arunoda/meteor-up/blob/mupx/lib/taskLists/linux.js).

--- a/example/mup.json
+++ b/example/mup.json
@@ -19,8 +19,8 @@
   "setupMongo": true,
 
   // mongorestore doesn't overwrite, without dropping/deleting per table first,
-  // the default is traditionally false
-  "restoreDrops": true,
+  // the default is traditionally to not drop, mupx changes thyat to drop by default (so noDrop is false)
+  //"noDrop": false,
 
   // When copying Mongo Backups don't delete the remote working temp folder (default /opt/backups/MDump_?)
   //"noCleanUp": false,

--- a/example/mup.json
+++ b/example/mup.json
@@ -18,6 +18,21 @@
   // Install MongoDB on the server. Does not destroy the local MongoDB on future setups
   "setupMongo": true,
 
+  // mongorestore doesn't overwrite, without dropping/deleting per table first,
+  // the default is traditionally false
+  "restoreDrops": true,
+
+  // When copying Mongo Backups don't delete the remote working temp folder (default /opt/backups/MDump_?)
+  //"noCleanUp": false,
+
+  // When you run Setup DESTROY the entire Remote Mongo database folder [must re-Deploy to resend database].
+  //"mongoStomp": false,
+
+  // Force the Remote Mongo lockfile to be deleted. A Lock when resending Setup can triggers container startup loops until resolved.
+  // this is unnecessary if mongoStomp is true.
+  //"mongoUnlock": true, // for safetly reason maybe using --mongoUnlock is prefered
+
+
   // Application name (no spaces).
   "appName": "meteor",
 

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -341,13 +341,11 @@ function prepMongoBackupRestore(mode) {
           idx -= 1;
         }
         else {
-          if(idx == (ma.length - 1)) {
+          if(ma[idx].indexOf("-") != 0) {
             ld = ma[idx];
-            if(ld.indexOf("-") != 0) {
-              ma.splice(idx, 1);
-              idx -= 1;
-              if(vbs) console.log("Set Local Source Folder (not filename):".bold.blue + ld);
-            }
+            ma.splice(idx, 1);
+            idx -= 1;
+            if(vbs) console.log("Set Local Source Folder (not filename):".bold.blue + ld);
           }
         }
       }

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -327,10 +327,10 @@ function prepMongoBackupRestore(mode) {
       idx -= 1;
     }
     else {
-      if(arg === "--restoredumps") {
-        config.restoreDumps = true;
+      if(arg === "--nodrop") {
+        config.noDrop = true;
         ma.splice(idx, 1);
-        if (vbs) console.log("Set Restore Dumps".bold.blue);
+        if (vbs) console.log("Set Restore No Drop".bold.blue);
         idx -= 1;
       }
       else {
@@ -351,22 +351,33 @@ function prepMongoBackupRestore(mode) {
       }
     }
   }
-  if(mode === "dump") {
-    if(ld.endsWith("/") == false) ld += "/";
+  if(ld.endsWith("/") == false) ld += "/";
+  if(vbs) console.log(ma);
+  config.locDir = ld;
+  if(fs.existsSync(ld) === true) {
+    if(fs.statSync(ld).isFile() === true) {
+      console.log("Error: Local Directory Found as FILE?! ".bold.red + ld);
+      return;
+    }
+    runMongoDumpRestore(mode);
   }
   else {
-    if(ld.endsWith("/") == true) ld = ld.substring(0, (ld.length - 1));
-  }
-  if(vbs) console.log(ma);
-  fs.exists(ld, function(exists) {
-    if(exists) {
-      config.locDir = ld;
+    console.log("Creating Directory: " + ld);
+    try {
+      fs.mkdirSync(ld);
       runMongoDumpRestore(mode);
     }
-    else {
-      console.log("Error: Local Directory Not Found ".bold.red + ld);
+    catch(err) {
+      if(err.code == "EACCES") {
+        execCommand("sudo mkdir " + ld, ld + " Created!", function () {
+          runMongoDumpRestore(mode);
+        });
+      }
+      else {
+        console.log("Creation Denied.");
+      }
     }
-  });
+  }
 }
 
 function runMongoDumpRestore(mode) {
@@ -404,8 +415,8 @@ function runDumpRestore(mode, fName, cpTarg) {
   }
   else {
     cmd += " mongorestore ";
-    var drop = config.restoreDrops || config.env.RESTORE_DROPS || process.env.RESTORE_DROPS || true;
-    if(drop === true || drop === 'true' || drop === '1') {
+    var noDrop = config.noDrop || config.env.NO_DROP || process.env.NO_DROP || false;
+    if(noDrop === false || noDrop === 'false' || noDrop === '0') {
       cmd += "--drop ";
     }
     cmd += config.myArgs.join(" ") + " " + cpTarg;

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -3,13 +3,14 @@ var path = require('path');
 var fs = require('fs');
 var rimraf = require('rimraf');
 var exec = require('child_process').exec;
-var spawn = require('child_process').spawn;
+//var spawn = require('child_process').spawn;
 var uuid = require('uuid');
-var format = require('util').format;
-var extend = require('util')._extend;
+//var format = require('util').format;
+//var extend = require('util')._extend;
 var _ = require('underscore');
 var async = require('async');
 var buildApp = require('./build.js');
+var ap = Actions.prototype;
 
 require('colors');
 
@@ -28,7 +29,7 @@ function Actions(config, cwd, options) {
   }
 }
 
-Actions.prototype._createSessionsMap = function(config) {
+ap._createSessionsMap = function(config) {
   var sessionsMap = {};
 
   config.servers.forEach(function(server) {
@@ -62,7 +63,7 @@ Actions.prototype._createSessionsMap = function(config) {
 };
 
 var kadiraRegex = /^meteorhacks:kadira/m;
-Actions.prototype._showKadiraLink = function() {
+ap._showKadiraLink = function() {
   var versionsFile = path.join(this.config.app, '.meteor/versions');
   if(fs.existsSync(versionsFile)) {
     var packages = fs.readFileSync(versionsFile, 'utf-8');
@@ -77,7 +78,7 @@ Actions.prototype._showKadiraLink = function() {
   }
 }
 
-Actions.prototype._executePararell = function(actionName, args) {
+ap._executePararell = function(actionName, args) {
   var self = this;
   var sessionInfoList = _.values(self.sessionsMap);
   async.map(
@@ -93,12 +94,15 @@ Actions.prototype._executePararell = function(actionName, args) {
   );
 };
 
-Actions.prototype.setup = function() {
+ap.setup = function() {
+  var args = process.argv.slice(3);
+  if(args.indexOf("--mongoStomp") > -1) this.config.mongoStomp = true;
+  else if(args.indexOf("--mongoUnlock") > -1) this.config.mongoUnlock = true;
   this._showKadiraLink();
   this._executePararell("setup", [this.config]);
 };
 
-Actions.prototype.deploy = function() {
+ap.deploy = function() {
   var self = this;
   self._showKadiraLink();
 
@@ -135,10 +139,9 @@ Actions.prototype.deploy = function() {
         sessionsData,
         function (sessionData, callback) {
           var session = sessionData.session;
-          var taskListsBuilder = sessionData.taskListsBuilder
+          var taskListsBuilder = sessionData.taskListsBuilder;
           var env = _.extend({}, self.config.env, session._serverConfig.env);
-          var taskList = taskListsBuilder.deploy(
-            bundlePath, env, self.config);
+          var taskList = taskListsBuilder.deploy(bundlePath, env, self.config);
           taskList.run(session, function (summaryMap) {
             callback(null, summaryMap);
           });
@@ -149,7 +152,7 @@ Actions.prototype.deploy = function() {
   });
 };
 
-Actions.prototype.reconfig = function() {
+ap.reconfig = function() {
   var self = this;
   var sessionInfoList = [];
   for(var os in self.sessionsMap) {
@@ -176,19 +179,19 @@ Actions.prototype.reconfig = function() {
   );
 };
 
-Actions.prototype.restart = function() {
+ap.restart = function() {
   this._executePararell("restart", [this.config]);
 };
 
-Actions.prototype.stop = function() {
+ap.stop = function() {
   this._executePararell("stop", [this.config]);
 };
 
-Actions.prototype.start = function() {
+ap.start = function() {
   this._executePararell("start", [this.config]);
 };
 
-Actions.prototype.logs = function() {
+ap.logs = function() {
   var self = this;
   var tailOptions = process.argv.slice(3).join(" ");
 
@@ -244,13 +247,243 @@ Actions.init  = function() {
   }
 };
 
-function storeLastNChars(vars, field, limit, color) {
-  return function(data) {
-    vars[field] += data.toString();
-    if(vars[field].length > 1000) {
-      vars[field] = vars[field].substring(vars[field].length - 1000);
+Date.prototype.defaultView = function(){
+	var dd = this.getDate();
+	if(dd < 10)dd = '0' + dd;
+	var mm = this.getMonth() + 1;
+	if(mm < 10) mm = '0' + mm;
+	var yyyy = this.getFullYear();
+	return String(yyyy + "-" + mm + "-" + dd);
+};
+
+String.prototype.endsWith = function (s) {
+  return this.length >= s.length && this.substr(this.length - s.length) == s;
+};
+
+ap.dump = ap.md = ap.mb = ap.backup = ap.mongobackup = ap.mongoBackup = ap.mongoDump = ap.mongodump = function() {
+  dockerIdSeach("mongo", "mongodb", "dockerId", prepMongoBackupRestore, "dump", this.config);
+};
+
+ap.restore = ap.mr = ap.mongoload = ap.mongoLoad = ap.ml = ap.load = ap.mongoRestore = ap.mongorestore  = function() {
+  dockerIdSeach("mongo", "mongodb", "dockerId", prepMongoBackupRestore, "restore", this.config);
+};
+
+ap.unlock = ap.mu = ap.mul = ap.mongounlock = ap.mongoUnlock = ap.mongounlocklocal = ap.mongoUnlockLocal = ap.mongounlock  = function() {
+  mongoUnlockLocal();
+};
+
+ap.unlockremote = ap.murt = ap.mongounlockremote = ap.unlockRemote = ap.mongoUnlockRemote = ap.mongounlockremote  = function() {
+  dockerIdSeach("mongo", "mongodb", "dockerId", mongoUnlockRemote);
+};
+
+/* well this is just a way to verify or find the real docker ID ~ adds flexibility */
+function dockerIdSeach(search, defaultId, store, success, args, config) {
+  if(store === "") return;
+  this.config = config = config || this.config || {}; // I know. I don't get it either. Codevolution@Work here.
+  search = search || defaultId || "mongodb";
+  exec("docker ps --format '{{.ID}}: {{.Command}} Names:{{.Names}}' | egrep '" + search + "' | sed 's/:.*//';", function (error, stdout) {
+    if (error !== null) {
+      console.log(error.toString().bold.red);
+    }
+    else {
+      config[store] = stdout.toString().replace(/(\r\n|\n|\r)/gm, "");
+      if(config.vbs) console.log(search + " = " + config[store]);
+      if(success !== undefined) success(args);
+    }
+  });
+}
+
+function prepMongoBackupRestore(mode) {
+  mode = mode || "dump";
+  var config = this.config;
+  config.appName = config.appName || "meteorApp";
+  config.myArgs = process.argv.slice(3);
+  var ma = config.myArgs;
+  var vbs = config.vbs = (ma.indexOf("-v") > -1);
+  var ld = '/opt/backups/';
+  var idx, arg;
+  for(idx = 0; idx < ma.length; idx++) {
+    arg = (ma[idx]).toLowerCase();
+    if(mode == "dump") {
+      if(arg == "--o" || arg == "--out") {
+        ld = ma[idx + 1];
+        ma.splice(idx, 2);
+        idx -= 1;
+        if(vbs) console.log("Set Local Destination Folder (not filename):".bold.green, ld);
+      }
+    }
+    else {
+      if(arg == "--i" || arg == "--in") {
+        ld = ma[idx + 1];
+        ma.splice(idx, 2);
+        idx -= 1;
+        if(vbs) console.log("Set Local Source Folder (not filename):".bold.blue + ld);
+      }
+    }
+    if(arg === "--cid" || arg === "--dockerid") {
+      config.dockerId = ma[idx + 1];
+      ma.splice(idx, 2);
+      if(vbs) console.log("Set Target DockerID:".bold.blue + config.dockerId);
+      idx -= 1;
+    }
+    else {
+      if(arg === "--restoredumps") {
+        config.restoreDumps = true;
+        ma.splice(idx, 1);
+        if (vbs) console.log("Set Restore Dumps".bold.blue);
+        idx -= 1;
+      }
+      else {
+        if(arg === "--nocleanup") {
+          config.noCleanUp = true;
+          ma.splice(idx, 1);
+          if (vbs) console.log("Set No-CleanUp".bold.blue);
+          idx -= 1;
+        }
+        else {
+          if(idx == (ma.length - 1)) {
+            ld = ma[idx];
+            if(ld.indexOf("-") != 0) {
+              ma.splice(idx, 1);
+              idx -= 1;
+              if(vbs) console.log("Set Local Source Folder (not filename):".bold.blue + ld);
+            }
+          }
+        }
+      }
     }
   }
+  if(mode === "dump") {
+    if(ld.endsWith("/") == false) ld += "/";
+  }
+  else {
+    if(ld.endsWith("/") == true) ld = ld.substring(0, (ld.length - 1));
+  }
+  if(vbs) console.log(ma);
+  fs.exists(ld, function(exists) {
+    if(exists) {
+      config.locDir = ld;
+      runMongoDumpRestore(mode);
+    }
+    else {
+      console.log("Error: Local Directory Not Found ".bold.red + ld);
+    }
+  });
+}
+
+function runMongoDumpRestore(mode) {
+  var config = this.config;
+  var mCon = config.dockerId;
+  if(mCon === undefined || mCon === "") {
+    console.log(('No Mongod Docker found running Aborting ' + mode).bold.red);
+    return;
+  }
+  console.log("Mongo Container: ".bold.cyan + mCon);
+  var ld = config.locDir;
+  var fName, genName = config.genName = "MDump_" + config.appName + "_" + (new Date).defaultView();
+  if(ld === '/opt/backups/') fName = (ld + genName);
+  else fName = ld;
+  if(mode === "dump") {
+    runDumpRestore(mode, "/opt/backups/" + genName, fName);
+  }
+  else {
+    var cpTarg = mCon + ":/opt/backups/" + genName;
+    var cmd = "sudo docker cp " + fName + " " + cpTarg;
+    console.log("Transferring: " + fName + "  " + String.fromCharCode(8631).bold.green + "  " + cpTarg);
+    execCommand(cmd, cpTarg + " Restoring!", function () {runDumpRestore(mode, fName, "/opt/backups/" + genName);});
+  }
+  /* NOTE: Execution reaches here before the exec's get to run for very long */
+}
+
+function runDumpRestore(mode, fName, cpTarg) {
+  var config = this.config;
+  var mCon = config.dockerId;
+  var ld = config.locDir;
+  var vbs = config.vbs;
+  var cmd = "sudo docker exec -t " + mCon;
+  if(mode === "dump") {
+    cmd += " mongodump --out " + fName + " " + config.myArgs.join(" ");
+  }
+  else {
+    cmd += " mongorestore ";
+    var drop = config.restoreDrops || config.env.RESTORE_DROPS || process.env.RESTORE_DROPS || true;
+    if(drop === true || drop === 'true' || drop === '1') {
+      cmd += "--drop ";
+    }
+    cmd += config.myArgs.join(" ") + " " + cpTarg;
+  }
+  if(vbs) console.log(cmd);
+  exec(cmd, function (error, stdout) {
+    if(error !== null) console.log(error.toString().bold.red);
+    else {
+      var dumpOp = stdout.toString();
+      if(dumpOp.length > 0) {
+        if(vbs) console.log("Mongo Dump/Restore Results (" + dumpOp.length + "):\n" + dumpOp);
+        if(dumpOp.toLowerCase().indexOf("failed") == -1) {
+          if(mode === "dump") {
+            if(!fs.existsSync(ld)) {
+              fs.mkdirSync(ld);
+            }
+            cmd = "sudo docker cp " + mCon + ":" + fName + " " + ld;
+            if(vbs) console.log(cmd);
+            ld += (cpTarg.indexOf(config.genName) == -1)?config.genName:"";
+            console.log("Transferring: " + ld + "  " + String.fromCharCode(8630).bold.green + "  " + fName);
+            execCommand(cmd, ld + " Complete!", function() {cleanUpRemote(mCon, fName);});
+          }
+          else {
+            cleanUpRemote(mCon, cpTarg);
+          }
+        }
+        else {
+          console.log("Error: Failure 'done' NOT Detected".bold.red);
+        }
+      }
+      else {
+        console.log("No report from mongodump".bold.red);
+      }
+    }
+  });
+}
+
+function cleanUpRemote(mCon, fName) {
+  var config = this.config;
+  var noCleanUp = config.noCleanUp || config.env.NO_CLEANUP || process.env.NO_CLEANUP || false;
+  if(noCleanUp === false || noCleanUp === 'false' || noCleanUp === '0') {
+    execCommandOn(mCon, "rm -r " + fName, "Clean-Up done for " + fName);
+  }
+}
+
+function mongoUnlockLocal() {
+  console.log("mongoUnlockLocal removing /var/lib/mongodb/mongod.lock from Local");
+  execCommand("sudo rm /var/lib/mongodb/mongod.lock", "Local Lock Removed /var/lib/mongodb/mongod.lock");
+}
+
+function mongoUnlockRemote() {
+  var dockerId = this.config.dockerId;
+  console.log("mongoUnlockRemote removing /data/db/mongod.lock from " + dockerId);
+  execCommandOn(dockerId, "rm /data/db/mongod.lock", "Lock Removed /data/db/mongod.lock");
+}
+
+function execCommandOn(mCon, cmd, successMsg, callback, args) {
+  if(mCon === undefined || mCon === "" || cmd === undefined || cmd === "") {
+    console.log("execCommandOn~ Command Not Valid! try running 'setup' maybe?");
+    return;
+  }
+  execCommand("sudo docker exec -t '" + mCon + "' " + cmd, mCon + ": " + successMsg, callback, args);
+}
+
+function execCommand(cmd, successMsg, callback, args) {
+  exec(cmd, function (error, stdout, stderr) {
+    if(error !== null) {
+      console.log(stdout.toString().bold.red);
+      console.log(error.toString().bold.red);
+    }
+    else {
+      console.log(stdout.toString().bold.green);
+      console.log(successMsg.toString().bold.green);
+      if(callback !== undefined) callback(args);
+    }
+  });
 }
 
 function whenAfterDeployed(buildLocation) {

--- a/lib/build.js
+++ b/lib/build.js
@@ -56,6 +56,7 @@ function archiveIt(buildLocaltion, callback) {
   var bundlePath = pathResolve(buildLocaltion, 'bundle.tar.gz');
   var sourceDir = pathResolve(buildLocaltion, 'bundle');
 
+  console.log("SrcDir: " + sourceDir);
   var output = fs.createWriteStream(bundlePath);
   var archive = archiver('tar', {
     gzip: true,

--- a/lib/build.js
+++ b/lib/build.js
@@ -3,22 +3,41 @@ var archiver = require('archiver');
 var fs = require('fs');
 var pathResolve = require('path').resolve;
 var _ = require('underscore');
+var fs = require('fs');
 
-function buildApp(appPath, buildLocaltion, buildOptions, callback) {
-  buildMeteorApp(appPath, buildLocaltion, buildOptions, function(code) {
-    if(code == 0) {
-      archiveIt(buildLocaltion, callback);
-    } else {
-      console.log("\n=> Build Error. Check the logs printed above.");
-      callback(new Error("build-error"));
-    }
-  });
+function buildApp(appPath, buildLocation, buildOptions, callback) {
+  if(buildOptions.mobileSettings) {
+    buildMeteorApp(appPath, buildLocation, buildOptions, function(code) {
+      if(code == 0) archiveIt(buildLocation, callback);
+      else {
+        console.log("\n=> Build Error. Check the logs printed above.");
+        callback(new Error("build-error"));
+      }
+    });
+  }
+  else {
+    fs.writeFile('.meteor/platforms', 'server\nbrowser\n', function(error) {
+      if(error) {
+        console.log("\n=> Error overwriting .meteor/platforms with only 'server' and 'browser' (no mobileSettings)!");
+        callback(new Error("build-error"));
+      }
+      else {
+        buildMeteorApp(appPath, buildLocation, buildOptions, function(code) {
+          if(code == 0) archiveIt(buildLocation, callback);
+          else {
+            console.log("\n=> Build Error. Check the logs printed above.");
+            callback(new Error("build-error"));
+          }
+        });
+      }
+    });
+  }
 }
 
-function buildMeteorApp(appPath, buildLocaltion, buildOptions, callback) {
+function buildMeteorApp(appPath, buildLocation, buildOptions, callback) {
   var executable = buildOptions.executable || "meteor";
   var args = [
-    "build", "--directory", buildLocaltion, 
+    "build", "--directory", buildLocation, 
     "--architecture", "os.linux.x86_64",
     "--server", "http://localhost:3000"
   ];
@@ -51,10 +70,10 @@ function buildMeteorApp(appPath, buildLocaltion, buildOptions, callback) {
   meteor.on('close', callback);
 }
 
-function archiveIt(buildLocaltion, callback) {
+function archiveIt(buildLocation, callback) {
   callback = _.once(callback);
-  var bundlePath = pathResolve(buildLocaltion, 'bundle.tar.gz');
-  var sourceDir = pathResolve(buildLocaltion, 'bundle');
+  var bundlePath = pathResolve(buildLocation, 'bundle.tar.gz');
+  var sourceDir = pathResolve(buildLocation, 'bundle');
 
   console.log("SrcDir: " + sourceDir);
   var output = fs.createWriteStream(bundlePath);

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -16,6 +16,18 @@ exports.printHelp = function() {
   console.error('start                  - Start your app instances');
   console.error('stop                   - Stop your app instances');
   console.error('restart                - Restart your app instances');
+  console.error('\nMongo Database Backup/Restore: (Local <-> first Docker mongod)');
+  console.error('           Optionally set any existing mongodump/mongorestore options,');
+  console.error('           but --out will be a Local Directory ONLY, not the filename.');
+  console.error('           and --oplog only works if it is configured for the database.');
+  console.error('mongoDump | md | dump - Backup docker Mongo Database to local folder');
+  console.error('mongoRestore | mr | restore - Restore docker Mongo Database from local folder');
+  console.error('           --noCleanup (default false) and --restoreDrops (default true)');
+  console.error('           These options are explained more in the readme but self-explanatory.');
+  console.error('mongoUnlock | mu - Unlock Mongo via local file /var/lib/mongodb/mongod.lock');
+  console.error('mongoUnlockRemote | murt - Unlock Mongo via remote file /data/db/mongod.lock ');
+  console.error('           If a newly Setup mongo container sees a previous lock it is unattachable,');
+  console.error('           as its restarting repeatedly.');
   console.error('\nAvailable Parameters (optional)');
   console.error('---------------------------------');
   console.error('--config=mup-prod.json - Specify the deployment configuration');

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -22,7 +22,7 @@ exports.printHelp = function() {
   console.error('           and --oplog only works if it is configured for the database.');
   console.error('mongoDump | md | dump - Backup docker Mongo Database to local folder');
   console.error('mongoRestore | mr | restore - Restore docker Mongo Database from local folder');
-  console.error('           --noCleanup (default false) and --restoreDrops (default true)');
+  console.error('           --noCleanup (default false) and --noDrop (mupx default is to override mongo default and add drop))');
   console.error('           These options are explained more in the readme but self-explanatory.');
   console.error('mongoUnlock | mu - Unlock Mongo via local file /var/lib/mongodb/mongod.lock');
   console.error('mongoUnlockRemote | murt - Unlock Mongo via remote file /data/db/mongod.lock ');

--- a/lib/taskLists/linux.js~
+++ b/lib/taskLists/linux.js~
@@ -1,7 +1,7 @@
 var nodemiral = require('nodemiral');
-//var fs = require('fs');
+var fs = require('fs');
 var path = require('path');
-//var util = require('util');
+var util = require('util');
 var _ = require('underscore');
 
 var SCRIPT_DIR = path.resolve(__dirname, '../../scripts/linux');
@@ -17,7 +17,7 @@ exports.setup = function(config) {
   taskList.executeScript('Setting up Environment', {
     script: path.resolve(SCRIPT_DIR, 'setup-env.sh'),
     vars: {
-      appName: config.appName || "meteorApp"
+      appName: config.appName
     }
   });
 
@@ -26,14 +26,9 @@ exports.setup = function(config) {
       src: path.resolve(TEMPLATES_DIR, 'mongodb.conf'),
       dest: '/opt/mongodb/mongodb.conf'
     });
-    config.mongoStomp = config.mongoStomp || config.env.MONGO_STOMP || process.env.MONGO_STOMP || false;
-    config.mongoUnlock = config.mongoUnlock || config.env.MONGO_UNLOCK || process.env.MONGO_UNLOCK || false;
+
     taskList.executeScript('Installing MongoDB', {
-      script: path.resolve(SCRIPT_DIR, 'install-mongodb.sh'),
-      vars: {
-        mongoStomp: config.mongoStomp || false,
-        mongoUnlock: config.mongoUnlock || false
-      }
+      script: path.resolve(SCRIPT_DIR, 'install-mongodb.sh')
     });
   }
 
@@ -134,6 +129,20 @@ exports.start = function(config) {
   var deployCheckWaitTime = config.deployCheckWaitTime;
 
   startAndVerify(taskList, appName, port, deployCheckWaitTime);
+
+  return taskList;
+};
+
+exports.mongodump = function(config) {
+  console.log("in taskList MongoDump");
+  var taskList = nodemiral.taskList("Dumping Mongo");
+
+  taskList.executeScript('Dump Mongo', {
+    script: path.resolve(SCRIPT_DIR, 'mongo-dump.sh'),
+    vars: {
+      appName: config.appName
+    }
+  });
 
   return taskList;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mupx",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Production Quality Meteor Deployments",
   "dependencies": {
     "async": "^0.9.0",

--- a/scripts/linux/deploy.sh
+++ b/scripts/linux/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 revert_app (){
-  if [[ -d old_app ]]; then
+  if sudo test -d old_app; then
     sudo rm -rf app
     sudo mv old_app app
     sudo stop <%= appName %> || :

--- a/scripts/linux/deploy.sh
+++ b/scripts/linux/deploy.sh
@@ -21,7 +21,7 @@ APP_DIR=/opt/<%=appName %>
 
 # save the last known version
 cd $APP_DIR
-if [[ -d current ]]; then
+if sudo test -d current; then
   sudo rm -rf last
   sudo mv current last
 fi

--- a/scripts/linux/install-docker.sh
+++ b/scripts/linux/install-docker.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Is docker already installed?
+echo "Docker Install Check..."
 set +e
 haveDocker=$(docker version | grep "version")
 set -e
@@ -19,4 +20,6 @@ if [ ! "$haveDocker" ]; then
 
   # Install docker
   wget -qO- https://get.docker.com/ | sudo sh
+else
+  echo "Docker Found!"
 fi

--- a/scripts/linux/install-mongodb.sh
+++ b/scripts/linux/install-mongodb.sh
@@ -3,11 +3,20 @@
 set -e
 # we use this data directory for the backward compatibility
 # older mup uses mongodb from apt-get and they used this data directory
-sudo mkdir -p /var/lib/mongodb
-
 sudo docker pull mongo:latest
 set +e
 sudo docker rm -f mongodb
+
+if [ "<%= mongoStomp %>" == true ]; then
+  sudo rm -r /var/lib/mongodb/
+else
+  if [ "<%= mongoUnlock %>" == true ]; then
+    echo "delete mongo lock"
+    sudo rm -r /var/lib/mongodb/mongod.lock
+  fi
+fi
+sudo mkdir -p /var/lib/mongodb
+
 set -e
 
 sudo docker run \
@@ -18,3 +27,4 @@ sudo docker run \
   --volume=/opt/mongodb/mongodb.conf:/mongodb.conf \
   --name=mongodb \
   mongo mongod -f /mongodb.conf
+

--- a/templates/linux/mongodb.conf
+++ b/templates/linux/mongodb.conf
@@ -1,1 +1,4 @@
-dbpath=/data/db
+storage:
+   dbPath: /data/db
+   journal:
+      enabled: false

--- a/templates/linux/start.sh
+++ b/templates/linux/start.sh
@@ -18,6 +18,8 @@ set +e
 docker pull meteorhacks/meteord:base
 set -e
 
+HOST_IP=`ip -4 addr show scope global dev eth0 | grep inet | awk '{print \$2}' | cut -d / -f 1`
+
 if [ "$USE_LOCAL_MONGO" == "1" ]; then
   docker run \
     -d \
@@ -27,6 +29,7 @@ if [ "$USE_LOCAL_MONGO" == "1" ]; then
     --env-file=$ENV_FILE \
     --link=mongodb:mongodb \
     --hostname="$HOSTNAME-$APPNAME" \
+    --add-host=dockerhost:$HOST_IP \
     --env=MONGO_URL=mongodb://mongodb:27017/$APPNAME \
     --name=$APPNAME \
     meteorhacks/meteord:base
@@ -37,6 +40,7 @@ else
     --publish=$PORT:80 \
     --volume=$BUNDLE_PATH:/bundle \
     --hostname="$HOSTNAME-$APPNAME" \
+    --add-host=dockerhost:$HOST_IP \
     --env-file=$ENV_FILE \
     --name=$APPNAME \
     meteorhacks/meteord:base


### PR DESCRIPTION
This adds mongodump and mongorestore functionality to mupx. One can use 
mupx mongodump
and
mupx mongorestore
to make a local backup/dump or restore.
It's maybe not the best approach but it seemed reasonable at the time to just add a simple 'docker exec' for each command and automatically sort out a date stamped Filename and just provide an option to override a default folder, instead of building more conditional scripts in the existing style.
Basically it seems that mupx is build from mup but using docker now, so that makes the os/platform specific scripts idea obsolete and only one linux is supported fully at this time, so it made more sense to me to not follow completely with the existing legacy design of scripts for this particular addition.
It adds these database backup support features that work and are requested and useful, but it demonstrates a slightly different approach, yet still optimized within the existing code base.
I've gone further with it then maybe was originally intended and so it needs review or extra testing and potentially some tweaking (at least with the docs).
There are a few extra added features hopefully well enough documented in the ReadMe and more briefly in the conf help.
Of course I could go on more in the written description but it is really rather simple if you want it to be to, and didn't want to over do it so a bare minimum was attempted.
I also added a mongoUnlock (and mongoUnlockRemote less useful) to help resolve jam outs when rerunning setup or situations where the mongo lock causes a reboot loop for the mongodb container.
All features have alias or shortcuts and can be used in the command line, mup.json config file, as well as via exported environment variables.
