### PR TITLE
Allow meteor to zip the binary instead of archiver

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -1,13 +1,13 @@
 var spawn = require('child_process').spawn;
-var archiver = require('archiver');
 var fs = require('fs');
-var pathResolve = require('path').resolve;
+var path = require('path');
+var pathResolve = path.resolve;
 var _ = require('underscore');
 
 function buildApp(appPath, meteorBinary, buildLocaltion, callback) {
   buildMeteorApp(appPath, meteorBinary, buildLocaltion, function(code) {
     if(code == 0) {
-      archiveIt(buildLocaltion, callback);
+      renameIt(appPath, buildLocaltion, callback);
     } else {
       console.log("\n=> Build Error. Check the logs printed above.");
       callback(new Error("build-error"));
@@ -15,11 +15,17 @@ function buildApp(appPath, meteorBinary, buildLocaltion, callback) {
   });
 }
 
+function renameIt(appPath, buildLocaltion, callback) {
+  var parts = appPath.split(path.sep);
+  var bundlePath = pathResolve(buildLocaltion, parts[parts.length - 1] + '.tar.gz');
+  var newBundlePath = pathResolve(buildLocaltion, 'bundle.tar.gz');
+  fs.rename(bundlePath, newBundlePath, callback);
+}
+
 function buildMeteorApp(appPath, meteorBinary, buildLocaltion, callback) {
   var executable = meteorBinary;
   var args = [
-    "build", "--directory", buildLocaltion, 
-    "--server", "http://localhost:3000"
+    "build", buildLocaltion
   ];
   
   var isWin = /^win/.test(process.platform);
@@ -39,30 +45,6 @@ function buildMeteorApp(appPath, meteorBinary, buildLocaltion, callback) {
   meteor.stderr.pipe(process.stderr, {end: false});
 
   meteor.on('close', callback);
-}
-
-function archiveIt(buildLocaltion, callback) {
-  callback = _.once(callback);
-  var bundlePath = pathResolve(buildLocaltion, 'bundle.tar.gz');
-  var sourceDir = pathResolve(buildLocaltion, 'bundle');
-
-  var output = fs.createWriteStream(bundlePath);
-  var archive = archiver('tar', {
-    gzip: true,
-    gzipOptions: {
-      level: 6
-    }
-  });
-
-  archive.pipe(output);
-  output.once('close', callback);
-
-  archive.once('error', function(err) {
-    console.log("=> Archiving failed:", err.message);
-    callback(err);
-  });
-
-  archive.directory(sourceDir, 'bundle').finalize();
 }
 
 module.exports = buildApp;


### PR DESCRIPTION
If you don't pass a `--directory` flag to meteor, it will zip the folder
for you.

The `archiver` package does not properly zip files with a colon in them.
For example, if you zip up a meteor build with `iron:router` and then
unzip that archived file, the output folder will be `ironrouter`.

Additionally, this removes the archiver code from this, which is nice.
