### PR TITLE
use docker network to avoid --link and more.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "async": "^0.9.0",
     "cjson": "0.3.x",
     "colors": "0.6.x",
-    "nodemiral": "^1.0.1",
+    "nodemiral": "^1.1.1",
     "rimraf": "2.x.x",
     "underscore": "1.7.0",
     "uuid": "1.4.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mupx",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Production Quality Meteor Deployments",
   "dependencies": {
     "async": "^0.9.0",

--- a/scripts/linux/install-docker.sh
+++ b/scripts/linux/install-docker.sh
@@ -20,3 +20,12 @@ if [ ! "$haveDocker" ]; then
   # Install docker
   wget -qO- https://get.docker.com/ | sudo sh
 fi
+
+set +e
+haveDockerNet=$(sudo docker network ls | grep "mupnet")
+set -e
+
+if [ ! "$haveDockerNet" ]; then
+  # Create a docker network
+  sudo docker network create --driver=bridge mupnet
+fi

--- a/scripts/linux/install-mongodb.sh
+++ b/scripts/linux/install-mongodb.sh
@@ -16,5 +16,6 @@ sudo docker run \
   --publish=127.0.0.1:27017:27017 \
   --volume=/var/lib/mongodb:/data/db \
   --volume=/opt/mongodb/mongodb.conf:/mongodb.conf \
+  --net=mupnet \
   --name=mongodb \
   mongo mongod -f /mongodb.conf

--- a/templates/linux/start.sh
+++ b/templates/linux/start.sh
@@ -25,9 +25,9 @@ if [ "$USE_LOCAL_MONGO" == "1" ]; then
     --publish=$PORT:80 \
     --volume=$BUNDLE_PATH:/bundle \
     --env-file=$ENV_FILE \
-    --link=mongodb:mongodb \
     --hostname="$HOSTNAME-$APPNAME" \
     --env=MONGO_URL=mongodb://mongodb:27017/$APPNAME \
+    --net=mupnet \
     --name=$APPNAME \
     meteorhacks/meteord:base
 else
@@ -38,6 +38,7 @@ else
     --volume=$BUNDLE_PATH:/bundle \
     --hostname="$HOSTNAME-$APPNAME" \
     --env-file=$ENV_FILE \
+    --net=mupnet \
     --name=$APPNAME \
     meteorhacks/meteord:base
 fi


### PR DESCRIPTION
Hello,

I've started to modified mupx (starting from the v1.5.3 tag) to use a docker bridge network to inter-connect mup application containers and mongodb container.

A "mupnet" network is first created  (install-docker.sh)
Then each container is started with --net=mupnet (no more --link in the useLocalMongo case) so each container knows others by name automatically (through a dynamically computed /etc/hosts).

I've not yet looked for the ssl frontend container, but have an idea. Tell me what you think about it :
The goal could be to have only one frontend container, common to all app containers which is automatically reconfigured with a new vhost when new meteor containers are created/started (using docker events and a small script). The frontend can handle ssl and no-ssl and proxy named vhost toward meteor containers (as there are in the same docker net).

Anthony.
