### PR TITLE
Add "publishPort" setting to suppress publish flag

### DIFF
--- a/example/mup.json
+++ b/example/mup.json
@@ -18,6 +18,9 @@
   // Install MongoDB on the server. Does not destroy the local MongoDB on future setups
   "setupMongo": true,
 
+  // Publish the port of the docker container
+  "publishPort": false,
+
   // Application name (no spaces).
   "appName": "meteor",
 
@@ -37,7 +40,7 @@
   // Before mup checks that, it will wait for the number of seconds configured below.
   "deployCheckWaitTime": 15,
 
-  // show a progress bar while uploading. 
+  // show a progress bar while uploading.
   // Make it false when you deploy using a CI box.
   "enableUploadProgressBar": true
 }

--- a/lib/taskLists/linux.js
+++ b/lib/taskLists/linux.js
@@ -74,7 +74,8 @@ exports.deploy = function(bundlePath, env, config) {
       appName: appName,
       useLocalMongo: config.setupMongo,
       port: env.PORT,
-      sslConfig: config.ssl
+      sslConfig: config.ssl,
+      publishPort: config.publishPort
     }
   });
 

--- a/templates/linux/start.sh
+++ b/templates/linux/start.sh
@@ -16,7 +16,10 @@ docker rm -f $APPNAME-frontend
 
 # We don't need to fail the deployment because of a docker hub downtime
 set +e
-docker pull meteorhacks/meteord:base
+docker build -t meteorhacks/meteord:app - << EOF
+FROM meteorhacks/meteord:base
+RUN apt-get install graphicsmagick -y
+EOF
 set -e
 
 if [ "$USE_LOCAL_MONGO" == "1" ]; then
@@ -31,7 +34,7 @@ if [ "$USE_LOCAL_MONGO" == "1" ]; then
       --hostname="$HOSTNAME-$APPNAME" \
       --env=MONGO_URL=mongodb://mongodb:27017/$APPNAME \
       --name=$APPNAME \
-      meteorhacks/meteord:base
+      meteorhacks/meteord:app
   else
     docker run \
       -d \
@@ -42,7 +45,7 @@ if [ "$USE_LOCAL_MONGO" == "1" ]; then
       --hostname="$HOSTNAME-$APPNAME" \
       --env=MONGO_URL=mongodb://mongodb:27017/$APPNAME \
       --name=$APPNAME \
-      meteorhacks/meteord:base
+      meteorhacks/meteord:app
   fi
 else
   if [ "$PUBLISH_PORT" == "1" ]; then
@@ -54,7 +57,7 @@ else
       --hostname="$HOSTNAME-$APPNAME" \
       --env-file=$ENV_FILE \
       --name=$APPNAME \
-      meteorhacks/meteord:base
+      meteorhacks/meteord:app
   else
     docker run \
       -d \
@@ -63,7 +66,7 @@ else
       --hostname="$HOSTNAME-$APPNAME" \
       --env-file=$ENV_FILE \
       --name=$APPNAME \
-      meteorhacks/meteord:base
+      meteorhacks/meteord:app
   fi
 fi
 

--- a/templates/linux/start.sh
+++ b/templates/linux/start.sh
@@ -6,6 +6,7 @@ BUNDLE_PATH=$APP_PATH/current
 ENV_FILE=$APP_PATH/config/env.list
 PORT=<%= port %>
 USE_LOCAL_MONGO=<%= useLocalMongo? "1" : "0" %>
+PUBLISH_PORT=<%= publishPort? "1": "0" %>
 
 # Remove previous version of the app, if exists
 docker rm -f $APPNAME
@@ -19,27 +20,51 @@ docker pull meteorhacks/meteord:base
 set -e
 
 if [ "$USE_LOCAL_MONGO" == "1" ]; then
-  docker run \
-    -d \
-    --restart=always \
-    --publish=$PORT:80 \
-    --volume=$BUNDLE_PATH:/bundle \
-    --env-file=$ENV_FILE \
-    --link=mongodb:mongodb \
-    --hostname="$HOSTNAME-$APPNAME" \
-    --env=MONGO_URL=mongodb://mongodb:27017/$APPNAME \
-    --name=$APPNAME \
-    meteorhacks/meteord:base
+  if [ "$PUBLISH_PORT" == "1" ]; then
+    docker run \
+      -d \
+      --restart=always \
+      --publish=$PORT:80 \
+      --volume=$BUNDLE_PATH:/bundle \
+      --env-file=$ENV_FILE \
+      --link=mongodb:mongodb \
+      --hostname="$HOSTNAME-$APPNAME" \
+      --env=MONGO_URL=mongodb://mongodb:27017/$APPNAME \
+      --name=$APPNAME \
+      meteorhacks/meteord:base
+  else
+    docker run \
+      -d \
+      --restart=always \
+      --volume=$BUNDLE_PATH:/bundle \
+      --env-file=$ENV_FILE \
+      --link=mongodb:mongodb \
+      --hostname="$HOSTNAME-$APPNAME" \
+      --env=MONGO_URL=mongodb://mongodb:27017/$APPNAME \
+      --name=$APPNAME \
+      meteorhacks/meteord:base
+  fi
 else
-  docker run \
-    -d \
-    --restart=always \
-    --publish=$PORT:80 \
-    --volume=$BUNDLE_PATH:/bundle \
-    --hostname="$HOSTNAME-$APPNAME" \
-    --env-file=$ENV_FILE \
-    --name=$APPNAME \
-    meteorhacks/meteord:base
+  if [ "$PUBLISH_PORT" == "1" ]; then
+    docker run \
+      -d \
+      --restart=always \
+      --publish=$PORT:80 \
+      --volume=$BUNDLE_PATH:/bundle \
+      --hostname="$HOSTNAME-$APPNAME" \
+      --env-file=$ENV_FILE \
+      --name=$APPNAME \
+      meteorhacks/meteord:base
+  else
+    docker run \
+      -d \
+      --restart=always \
+      --volume=$BUNDLE_PATH:/bundle \
+      --hostname="$HOSTNAME-$APPNAME" \
+      --env-file=$ENV_FILE \
+      --name=$APPNAME \
+      meteorhacks/meteord:base
+  fi
 fi
 
 <% if(typeof sslConfig === "object")  { %>


### PR DESCRIPTION
When I wanted to use https://github.com/jwilder/nginx-proxy to automatically route a meteor docker container started with mupx I ran into the issue of the "--publish" flag that is on by default.
I added a flag to the mup.json to disable this parameter in the docker run command so that port 80 is exposed (per Dockerfile) but not published.
This enables nginx-proxy to correctly route to port 80 of the docker container.
