### PR TITLE
Up to date version of Node for Meteor

### DIFF
--- a/scripts/linux/install-node.sh
+++ b/scripts/linux/install-node.sh
@@ -14,7 +14,7 @@ sudo apt-get update
 <% if (nodeVersion) { %>
   NODE_VERSION=<%= nodeVersion %>
 <% } else {%>
-  NODE_VERSION=0.10.36
+  NODE_VERSION=0.10.40
 <% } %>
 
 ARCH=$(python -c 'import platform; print platform.architecture()[0]')


### PR DESCRIPTION
I had errors deploying because now Meteor fails with words: "Meteor requires Node v0.10.40 or later"
