### PR TITLE
Up to date version of Node for Meteor

### DIFF
--- a/example/mup.json
+++ b/example/mup.json
@@ -17,7 +17,7 @@
   "setupNode": true,
 
   // WARNING: If nodeVersion omitted will setup 0.10.36 by default. Do not use v, only version number.
-  "nodeVersion": "0.10.36",
+  "nodeVersion": "0.10.40",
 
   // Install PhantomJS in the server
   "setupPhantom": true,


### PR DESCRIPTION
I had errors deploying because now Meteor fails with words: "Meteor requires Node v0.10.40 or later"
