### PR TITLE
Up to date version of Node for Meteor

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ This will create two files in your Meteor Up project directory:
   // WARNING: Node.js is required! Only skip if you already have Node.js installed on server.
   "setupNode": true,
 
-  // WARNING: nodeVersion defaults to 0.10.36 if omitted. Do not use v, just the version number.
-  "nodeVersion": "0.10.36",
+  // WARNING: nodeVersion defaults to 0.10.40 if omitted. Do not use v, just the version number.
+  "nodeVersion": "0.10.40",
 
   // Install PhantomJS on the server
   "setupPhantom": true,


### PR DESCRIPTION
I had errors deploying because now Meteor fails with words: "Meteor requires Node v0.10.40 or later"

(sorry for multiple pulls, I'm using the web interface, there is probable a fix required for sunos script)
