### PR TITLE
Fixed an issue in the env.sh template for linux

### DIFF
--- a/templates/linux/env.sh
+++ b/templates/linux/env.sh
@@ -5,5 +5,5 @@ export ROOT_URL=http://localhost
 
 #it is possible to override above env-vars from the user-provided values
 <% for(var key in env) { %>
-  export <%- key %>=<%- ("" + env[key]).replace(/./ig, '\\$&') %>
+export <%- key %>="<%- ("" + env[key]).replace(/\"/ig, '\\$&') %>"
 <% } %>


### PR DESCRIPTION
- there were spurious spaces in front of the exports that caused an
  error for me (surprised noone else reported that yet).
