### PR TITLE
Added build options to mupjson to send build  arguments to meteor

### DIFF
--- a/example/mup.json
+++ b/example/mup.json
@@ -22,7 +22,7 @@
   // Install PhantomJS in the server
   "setupPhantom": true,
 
-  // Show a progress bar during the upload of the bundle to the server. 
+  // Show a progress bar during the upload of the bundle to the server.
   // Might cause an error in some rare cases if set to true, for instance in Shippable CI
   "enableUploadProgressBar": true,
 
@@ -39,5 +39,10 @@
 
   // Meteor Up checks if the app comes online just after the deployment
   // before mup checks that, it will wait for no. of seconds configured below
-  "deployCheckWaitTime": 15
+  "deployCheckWaitTime": 15,
+
+  // Send arguments to meteor build proccess
+  "buildOptions": [
+    "--debug"
+  ],
 }

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -113,9 +113,9 @@ Actions.prototype.deploy = function() {
   var appPath = this.config.app;
   var enableUploadProgressBar = this.config.enableUploadProgressBar;
   var meteorBinary = this.config.meteorBinary;
-
+  var buildOptions = this.config.buildOptions;
   console.log('Building Started: ' + this.config.app);
-  buildApp(appPath, meteorBinary, buildLocation, function(err) {
+  buildApp(appPath, meteorBinary, buildLocation, buildOptions, function(err) {
     if(err) {
       process.exit(1);
     } else {

--- a/lib/build.js
+++ b/lib/build.js
@@ -4,8 +4,8 @@ var fs = require('fs');
 var pathResolve = require('path').resolve;
 var _ = require('underscore');
 
-function buildApp(appPath, meteorBinary, buildLocaltion, callback) {
-  buildMeteorApp(appPath, meteorBinary, buildLocaltion, function(code) {
+function buildApp(appPath, meteorBinary, buildLocaltion, buildOptions, callback) {
+  buildMeteorApp(appPath, meteorBinary, buildLocaltion, buildOptions, function(code) {
     if(code == 0) {
       archiveIt(buildLocaltion, callback);
     } else {
@@ -15,13 +15,19 @@ function buildApp(appPath, meteorBinary, buildLocaltion, callback) {
   });
 }
 
-function buildMeteorApp(appPath, meteorBinary, buildLocaltion, callback) {
+function buildMeteorApp(appPath, meteorBinary, buildLocaltion, buildOptions, callback) {
   var executable = meteorBinary;
   var args = [
-    "build", "--directory", buildLocaltion, 
+    "build", "--directory", buildLocaltion,
     "--server", "http://localhost:3000"
   ];
-  
+
+  if(buildOptions) {
+    _.forEach(buildOptions, function(option) {
+      args.push(option);
+    });
+  }
+
   var isWin = /^win/.test(process.platform);
   if(isWin) {
     // Sometimes cmd.exe not available in the path

--- a/lib/config.js
+++ b/lib/config.js
@@ -13,6 +13,7 @@ exports.read = function() {
 
     //initialize options
     mupJson.env = mupJson.env || {};
+    mupJson.buildOptions = mupJson.buildOptions || {};
 
     if(typeof mupJson.setupNode === "undefined") {
       mupJson.setupNode = true;


### PR DESCRIPTION
Added buildOptions to mup.json to send custom params to meteor build proccess.

This is useful for send --debug to prevent an issue with angular2 in production mode.
