### PR TITLE
add comma to pem line in mup.json

### DIFF
--- a/example/mup.json
+++ b/example/mup.json
@@ -7,7 +7,7 @@
       "password": "password",
       // or pem file (ssh based authentication)
       // WARNING: Keys protected by a passphrase are not supported
-      //"pem": "~/.ssh/id_rsa"
+      //"pem": "~/.ssh/id_rsa",
       // Also, for non-standard ssh port use this
       //"sshOptions": { "port" : 49154 },
       // server specific environment variables


### PR DESCRIPTION
I _always_ forget to add the comma, and just uncomment/edit this line. Now you can just uncomment this line and comment the password line, saving you _milliseconds upon milliseconds of hard work!_
