### PR TITLE
Make mup compatible with Meteor 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Meteor Up
 
-> This version is no longer maintaining.<br/>
-> [Mupx](https://github.com/arunoda/meteor-up/tree/mupx) is the stable version. <br/>
-> New development is moved to here: https://github.com/kadirahq/meteor-up.
+> This is a Meteor 1.4-ready fork of initial meteor-up project.<br/>
+> It uses Node 4.4.7 and MongoDB 3.2 by default.
+> Docker-enabled version is developed by KadiraHQ here: https://github.com/kadirahq/meteor-up.
 
 #### Production Quality Meteor Deployments
 
@@ -11,8 +11,6 @@ Meteor Up (mup for short) is a command line tool that allows you to deploy any [
 You can use install and use Meteor Up from Linux, Mac and Windows.
 
 > Screencast: [How to deploy a Meteor app with Meteor Up (by Sacha Greif)](https://www.youtube.com/watch?v=WLGdXtZMmiI)
-
-**Note:** This fork is Meteor 1.4-ready. It uses Node 4.4.7 and MongoDB 3.2 by default.
 
 **Table of Contents**
 
@@ -61,7 +59,12 @@ You can use install and use Meteor Up from Linux, Mac and Windows.
 
 ### Installation
 
-    npm install -g mup
+**Note:** These instructions are for installing this fork of meteor-up.
+
+    npm remove -g mup # Only if you already installed mup before
+    git clone https://github.com/M4v3R/meteor-up
+    cd meteor-up
+    npm install -g
 
 ### Creating a Meteor Up Project
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ This will setup the server for the `mup` deployments. It will take around 2-5 mi
 
 This will bundle the Meteor project and deploy it to the server.
 
+#### Deploying prebuilt bundle
+
+While deploying you can omit the building phase if you already have a prebuilt bundle. Just append its path to the deploy command:
+
+    mup deploy /path/to/bundle.tar.gz
+
 ### Additional Setup/Deploy Information
 
 #### Deploy Wait Time

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ You can use install and use Meteor Up from Linux, Mac and Windows.
 
 > Screencast: [How to deploy a Meteor app with Meteor Up (by Sacha Greif)](https://www.youtube.com/watch?v=WLGdXtZMmiI)
 
+**Note:** This fork is Meteor 1.4-ready. It uses Node 4.4.7 and MongoDB 3.2 by default.
+
 **Table of Contents**
 
 - [Features](#features)
@@ -100,7 +102,7 @@ This will create two files in your Meteor Up project directory:
   "setupNode": true,
 
   // WARNING: nodeVersion defaults to 0.10.43 if omitted. Do not use v, just the version number.
-  "nodeVersion": "0.10.43",
+  "nodeVersion": "4.4.7",
 
   // Install PhantomJS on the server
   "setupPhantom": true,

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ This will create two files in your Meteor Up project directory:
   // WARNING: Node.js is required! Only skip if you already have Node.js installed on server.
   "setupNode": true,
 
-  // WARNING: nodeVersion defaults to 0.10.36 if omitted. Do not use v, just the version number.
-  "nodeVersion": "0.10.36",
+  // WARNING: nodeVersion defaults to 0.10.43 if omitted. Do not use v, just the version number.
+  "nodeVersion": "0.10.43",
 
   // Install PhantomJS on the server
   "setupPhantom": true,

--- a/example/mup.json
+++ b/example/mup.json
@@ -16,8 +16,8 @@
   // WARNING: Node.js is required! Only skip if you already have Node.js installed on server.
   "setupNode": true,
 
-  // WARNING: If nodeVersion omitted will setup 0.10.36 by default. Do not use v, only version number.
-  "nodeVersion": "0.10.36",
+  // WARNING: If nodeVersion omitted will setup 0.10.43 by default. Do not use v, only version number.
+  "nodeVersion": "0.10.43",
 
   // Install PhantomJS in the server
   "setupPhantom": true,

--- a/example/mup.json
+++ b/example/mup.json
@@ -17,12 +17,12 @@
   "setupNode": true,
 
   // WARNING: If nodeVersion omitted will setup 0.10.43 by default. Do not use v, only version number.
-  "nodeVersion": "0.10.43",
+  "nodeVersion": "4.4.7",
 
   // Install PhantomJS in the server
   "setupPhantom": true,
 
-  // Show a progress bar during the upload of the bundle to the server. 
+  // Show a progress bar during the upload of the bundle to the server.
   // Might cause an error in some rare cases if set to true, for instance in Shippable CI
   "enableUploadProgressBar": true,
 

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -113,40 +113,57 @@ Actions.prototype.deploy = function() {
   var appPath = this.config.app;
   var enableUploadProgressBar = this.config.enableUploadProgressBar;
   var meteorBinary = this.config.meteorBinary;
+  var prebuiltBundle = process.argv.slice(3).join(" ");
+  if (prebuiltBundle && !fs.existsSync(prebuiltBundle)) {
+    console.error('Error: bundle not found!'.bold.red);
+    process.exit(1);
+  }
 
-  console.log('Building Started: ' + this.config.app);
-  buildApp(appPath, meteorBinary, buildLocation, function(err) {
-    if(err) {
-      process.exit(1);
-    } else {
-      var sessionsData = [];
-      _.forEach(self.sessionsMap, function (sessionsInfo) {
-        var taskListsBuilder = sessionsInfo.taskListsBuilder;
-        _.forEach(sessionsInfo.sessions, function (session) {
-          sessionsData.push({
-            taskListsBuilder: taskListsBuilder,
-            session: session
-          });
+  var deployFunc = function() {
+    var sessionsData = [];
+    _.forEach(self.sessionsMap, function (sessionsInfo) {
+      var taskListsBuilder = sessionsInfo.taskListsBuilder;
+      _.forEach(sessionsInfo.sessions, function (session) {
+        sessionsData.push({
+          taskListsBuilder: taskListsBuilder,
+          session: session
         });
       });
+    });
 
-      async.mapSeries(
-        sessionsData,
-        function (sessionData, callback) {
-          var session = sessionData.session;
-          var taskListsBuilder = sessionData.taskListsBuilder;
-          var env = _.extend({}, self.config.env, session._serverConfig.env);
-          var taskList = taskListsBuilder.deploy(
-            bundlePath, env,
-            deployCheckWaitTime, appName, enableUploadProgressBar);
-          taskList.run(session, function (summaryMap) {
-            callback(null, summaryMap);
-          });
-        },
-        whenAfterDeployed(buildLocation)
-      );
-    }
-  });
+    async.mapSeries(
+      sessionsData,
+      function (sessionData, callback) {
+        var session = sessionData.session;
+        var taskListsBuilder = sessionData.taskListsBuilder;
+        var env = _.extend({}, self.config.env, session._serverConfig.env);
+        var taskList = taskListsBuilder.deploy(
+          bundlePath, env,
+          deployCheckWaitTime, appName, enableUploadProgressBar);
+        taskList.run(session, function (summaryMap) {
+          callback(null, summaryMap);
+        });
+      },
+      whenAfterDeployed(buildLocation)
+    );
+  }
+
+  if (!prebuiltBundle) {
+    console.log('Building Started: ' + this.config.app);
+    console.log('Bundle path: ' + bundlePath);
+    buildApp(appPath, meteorBinary, buildLocation, function(err) {
+      if(err) {
+        process.exit(1);
+      } else {
+        deployFunc();
+      }
+    });
+  }
+  else {
+    console.log('Deploying prebuilt bundle: ' + bundlePath);
+    bundlePath = prebuiltBundle;
+    deployFunc();
+  }
 };
 
 Actions.prototype.reconfig = function() {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -6,7 +6,7 @@ exports.printHelp = function() {
   console.error('init          - Initialize a Meteor Up project');
   console.error('setup         - Setup the server');
   console.error('');
-  console.error('deploy        - Deploy app to server');
+  console.error('deploy [path] - Deploy app to server (optionally with prebuilt bundle.tar.gz)');
   console.error('reconfig      - Reconfigure the server and restart');
   console.error('');
   console.error('logs [-f -n]  - Access logs');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mup",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Production Quality Meteor Deployments",
   "dependencies": {
     "async": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "rimraf": "2.x.x",
     "underscore": "1.7.0",
     "uuid": "1.4.x",
-    "archiver": "0.14.x"
+    "archiver": "^1.3.0"
   },
   "bin": {
     "mup": "./bin/mup"

--- a/scripts/linux/install-mongodb.sh
+++ b/scripts/linux/install-mongodb.sh
@@ -7,8 +7,8 @@ sudo rm /var/cache/apt/archives/lock > /dev/null
 sudo dpkg --configure -a
 set -e
 
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
-echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
+echo "deb http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.2 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb.list
 sudo apt-get update -y
 sudo apt-get install mongodb-org mongodb-org-server mongodb-org-shell mongodb-org-tools -y
 

--- a/scripts/linux/install-node.sh
+++ b/scripts/linux/install-node.sh
@@ -14,7 +14,7 @@ sudo apt-get update
 <% if (nodeVersion) { %>
   NODE_VERSION=<%= nodeVersion %>
 <% } else {%>
-  NODE_VERSION=0.10.36
+  NODE_VERSION=0.10.43
 <% } %>
 
 ARCH=$(python -c 'import platform; print platform.architecture()[0]')

--- a/scripts/linux/install-node.sh
+++ b/scripts/linux/install-node.sh
@@ -36,3 +36,7 @@ sudo mv ${NODE_DIST} /opt/nodejs
 
 sudo ln -sf /opt/nodejs/bin/node /usr/bin/node
 sudo ln -sf /opt/nodejs/bin/npm /usr/bin/npm
+
+# Install node-gyp and remove old files if necessary
+sudo npm install -g node-gyp
+sudo rm -rf ~/.node-gyp*

--- a/scripts/linux/install-phantomjs.sh
+++ b/scripts/linux/install-phantomjs.sh
@@ -10,10 +10,10 @@ set -e
 # Install PhantomJS
 sudo apt-get -y install libfreetype6 libfreetype6-dev fontconfig > /dev/null
 ARCH=`uname -m`
-PHANTOMJS_VERSION=1.9.8
+PHANTOMJS_VERSION=2.1.1
 
 cd /usr/local/share/
-sudo wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-${PHANTOMJS_VERSION}-linux-${ARCH}.tar.bz2 > /dev/null
+sudo curl -L -O https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-${PHANTOMJS_VERSION}-linux-${ARCH}.tar.bz2 > /dev/null
 sudo tar xjf phantomjs-${PHANTOMJS_VERSION}-linux-${ARCH}.tar.bz2  > /dev/null
 sudo ln -s -f /usr/local/share/phantomjs-${PHANTOMJS_VERSION}-linux-${ARCH}/bin/phantomjs /usr/local/share/phantomjs
 sudo ln -s -f /usr/local/share/phantomjs-${PHANTOMJS_VERSION}-linux-${ARCH}/bin/phantomjs /usr/local/bin/phantomjs

--- a/scripts/sunos/install-node.sh
+++ b/scripts/sunos/install-node.sh
@@ -4,7 +4,7 @@
 <% if (nodeVersion) { %>
   NODE_VERSION=<%= nodeVersion %>
 <% } else {%>
-  NODE_VERSION=0.10.36
+  NODE_VERSION=0.10.43
 <% } %>
 
 ARCH=$(python -c 'import platform; print platform.architecture()[0]')

--- a/templates/linux/deploy.sh
+++ b/templates/linux/deploy.sh
@@ -52,6 +52,10 @@ rebuild_binary_npm_modules () {
       cd $package/node_modules
         gyp_rebuild_inside_node_modules
       cd ../../../
+    elif [ -d $package ]; then # Meteor 1.3
+      cd $package
+        rebuild_binary_npm_modules
+      cd ..
     fi
   done
 }
@@ -89,7 +93,13 @@ cd ${BUNDLE_DIR}/programs/server
 
 if [ -d ./npm ]; then
   cd npm
-  rebuild_binary_npm_modules
+  if [ -d ./node_modules ]; then # Meteor 1.3
+    cd node_modules
+    rebuild_binary_npm_modules
+    cd ..
+  else
+    rebuild_binary_npm_modules
+  fi
   cd ../
 fi
 

--- a/templates/linux/deploy.sh
+++ b/templates/linux/deploy.sh
@@ -15,11 +15,13 @@ gyp_rebuild_inside_node_modules () {
       if [ $isBinaryModule != "yes" ]; then
         if [ -d ./node_modules ]; then
           cd ./node_modules
-          for module in ./*; do
-            cd $module
-            check_for_binary_modules
-            cd ..
-          done
+          if [ "$(ls ./ )" ]; then
+            for module in ./*; do
+              cd $module
+              check_for_binary_modules
+              cd ..
+            done
+	      fi
           cd ../
         fi
       fi


### PR DESCRIPTION
This patch does few things:
- updates Node version to 0.10.43, which is required for Meteor 1.3
- updates `deploy.sh` script to properly re-build binary npm packages on 1.3
- while at it, updates MongoDB to 3.2 and PhantomJS to 2.1.1

I understand that mup is currently not actively maintained, but I think it would be nice to make it compatible with 1.3 at least, as there are still some people that rely on this excellent tool.
