### PR TITLE
Add server-only option for mupx deploys

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -18,9 +18,10 @@ function buildApp(appPath, buildLocaltion, buildOptions, callback) {
 function buildMeteorApp(appPath, buildLocaltion, buildOptions, callback) {
   var executable = buildOptions.executable || "meteor";
   var args = [
-    "build", "--directory", buildLocaltion, 
+    "build", "--directory", buildLocaltion,
     "--architecture", "os.linux.x86_64",
-    "--server", "http://localhost:3000"
+    "--server", "http://localhost:3000",
+    "--server-only"
   ];
 
   if(buildOptions.debug) {
@@ -31,7 +32,7 @@ function buildMeteorApp(appPath, buildLocaltion, buildOptions, callback) {
     args.push('--mobile-settings');
     args.push(JSON.stringify(buildOptions.mobileSettings));
   }
-  
+
   var isWin = /^win/.test(process.platform);
   if(isWin) {
     // Sometimes cmd.exe not available in the path


### PR DESCRIPTION
Backport from KadiraHQ of [pr](https://github.com/kadirahq/meteor-up/pull/120/commits/e8d10aaf735ea5ddb07acdd486a15e54cbb9af5f)

This adds the --server-only option to mupx.  See also: #1012, #1005, https://github.com/kadirahq/meteor-up/issues/130, and https://github.com/kadirahq/meteor-up/issues/121
