### PR TITLE
Fix to Deploying with Node 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "rimraf": "2.x.x",
     "underscore": "1.7.0",
     "uuid": "1.4.x",
-    "archiver": "0.14.x",
+    "archiver": "1.0.0",
     "update-notifier": "0.4.x",
     "minimist": "1.1.1"
   },


### PR DESCRIPTION
When running mupx with Node 6 the following error occurs:

```
buffer.js:106
      throw new Error(
      ^

Error: If encoding is specified then the first argument must be a string
    at new Buffer (buffer.js:106:13)
    at Readable.<anonymous> (/usr/local/lib/node_modules/mupx/node_modules/archiver/lib/util/index.js:32:15)
    at emitNone (events.js:91:20)
    at Readable.emit (events.js:185:7)
    at endReadableNT (_stream_readable.js:926:12)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```

This update fixes the problem.
