### PR TITLE
Fix for Issue: https://github.com/arunoda/meteor-up/issues/1007

### DIFF
--- a/scripts/linux/install-node.sh
+++ b/scripts/linux/install-node.sh
@@ -32,6 +32,7 @@ cd /tmp
 wget http://nodejs.org/dist/v${NODE_VERSION}/${NODE_DIST}.tar.gz
 tar xvzf ${NODE_DIST}.tar.gz
 sudo rm -rf /opt/nodejs
+sudo mkdir -p /opt/nodejs
 sudo mv ${NODE_DIST} /opt/nodejs
 
 sudo ln -sf /opt/nodejs/bin/node /usr/bin/node

--- a/scripts/sunos/install-node.sh
+++ b/scripts/sunos/install-node.sh
@@ -22,6 +22,7 @@ cd /tmp
 wget http://nodejs.org/dist/v${NODE_VERSION}/${NODE_DIST}.tar.gz
 tar xvzf ${NODE_DIST}.tar.gz
 sudo rm -rf /opt/nodejs
+sudo mkdir -p /opt/nodejs
 sudo mv ${NODE_DIST} /opt/nodejs
 
 # set downloaded node version as the default


### PR DESCRIPTION
This fixes issue https://github.com/arunoda/meteor-up/issues/1007, where mup deploy fails because directory "/opt/nodejs" does not exist.

Also related to: https://forums.meteor.com/t/syntax-error-on-mup-setup/22930/4
